### PR TITLE
check primary metrics for AccuracyCalculator and logging_presets

### DIFF
--- a/src/pytorch_metric_learning/utils/accuracy_calculator.py
+++ b/src/pytorch_metric_learning/utils/accuracy_calculator.py
@@ -49,6 +49,7 @@ class AccuracyCalculator:
         function_names = [x for x in dir(self) if x.startswith(self.function_keyword)]
         metrics = [x.replace(self.function_keyword, "", 1) for x in function_names]
         self.original_function_dict = {x:getattr(self, y) for x,y in zip(metrics, function_names)}
+        self.check_primary_metrics(include, exclude)
         self.original_function_dict = self.get_function_dict(include, exclude)
         self.curr_function_dict = self.get_function_dict()
 
@@ -111,3 +112,11 @@ class AccuracyCalculator:
 
     def _get_accuracy(self, function_dict, **kwargs):
         return {k:v(**kwargs) for k,v in function_dict.items()}
+
+    def check_primary_metrics(calc, include=(), exclude=()):
+        primary_metrics = list(calc.original_function_dict.keys())
+        for met in [include, exclude]:
+            if not isinstance(met, (tuple, list)):
+                raise TypeError("Arguments must be of type tuple, not {}.".format(type(met)))
+            if not set(met).issubset(set(primary_metrics)):
+                raise ValueError("Primary metrics must be one or more of: {}.".format(primary_metrics))

--- a/src/pytorch_metric_learning/utils/logging_presets.py
+++ b/src/pytorch_metric_learning/utils/logging_presets.py
@@ -43,6 +43,8 @@ class HookContainer:
 
     # This hook will be passed into the trainer and will be executed at the end of every epoch.
     def end_of_epoch_hook(self, tester, dataset_dict, model_folder, test_interval=1, patience=None, test_collate_fn=None):
+        if not self.primary_metric in tester.accuracy_calculator.get_curr_metrics():
+            raise ValueError("HookContainer `primary_metric` must be one of: {}".format(tester.accuracy_calculator.get_curr_metrics()))
         if not os.path.exists(model_folder): os.makedirs(model_folder)
         def actual_hook(trainer):
             continue_training = True


### PR DESCRIPTION
This pull request has the appropriate minimal changes.

- check `include` and `exclude` metrics are viable
- check HookContainer `primary_metric` is in `tester.accuracy_calculator`

I ran into some noninformative errors when I passed `include=('AMI')` and realize the same happens if HookContainer `primary_metric` is not checked. 