### PR TITLE
Resolved edge case for DistanceWeightedMiner

### DIFF
--- a/src/pytorch_metric_learning/miners/distance_weighted_miner.py
+++ b/src/pytorch_metric_learning/miners/distance_weighted_miner.py
@@ -43,9 +43,6 @@ class DistanceWeightedMiner(BaseTupleMiner):
         weights = weights * mask * ((mat < self.nonzero_loss_cutoff).type(dtype))
         weights[inf_or_nan] = 0
 
-        empty_weights = mask.byte() * (torch.sum(weights, dim=1) == 0).unsqueeze(1).byte()
-        weights[empty_weights] = 1e-16
-
         weights = weights / torch.sum(weights, dim=1, keepdim=True)
 
         return lmu.get_random_triplet_indices(

--- a/src/pytorch_metric_learning/miners/distance_weighted_miner.py
+++ b/src/pytorch_metric_learning/miners/distance_weighted_miner.py
@@ -42,6 +42,10 @@ class DistanceWeightedMiner(BaseTupleMiner):
 
         weights = weights * mask * ((mat < self.nonzero_loss_cutoff).type(dtype))
         weights[inf_or_nan] = 0
+
+        empty_weights = mask.byte() * (torch.sum(weights, dim=1) == 0).unsqueeze(1).byte()
+        weights[empty_weights] = 1e-16
+
         weights = weights / torch.sum(weights, dim=1, keepdim=True)
 
         return lmu.get_random_triplet_indices(

--- a/src/pytorch_metric_learning/utils/loss_and_miner_utils.py
+++ b/src/pytorch_metric_learning/utils/loss_and_miner_utils.py
@@ -127,6 +127,12 @@ def get_random_triplet_indices(
         # Get indices of negative samples for this label.
         if weights is not None:
             w = weights[:, n_inds][a]
+            non_zero_rows = torch.where(torch.sum(w, dim=1) > 0)[0]
+            if len(non_zero_rows) == 0:
+                continue
+            w = w[non_zero_rows]
+            a = a[non_zero_rows]
+            p = p[non_zero_rows]
             # Sample the negative indices according to the weights.
             if w.dtype == torch.float16:
                 # special case needed due to pytorch cuda bug

--- a/tests/miners/test_distance_weighted_miner.py
+++ b/tests/miners/test_distance_weighted_miner.py
@@ -36,10 +36,14 @@ class TestDistanceWeightedMiner(unittest.TestCase):
                 )
             min_an_dist = torch.min(all_an_dist)
 
-            for non_zero_cutoff_int in range(5, 15):
+            cutoffs = [0] + list(range(5, 15))
+            for non_zero_cutoff_int in cutoffs:
                 non_zero_cutoff = (float(non_zero_cutoff_int) / 10.0) - 0.01
                 miner = DistanceWeightedMiner(0, non_zero_cutoff)
                 a, p, n = miner(embeddings, labels, ref_embeddings, ref_labels)
+                if non_zero_cutoff_int == 0:
+                    self.assertTrue(len(a) == len(p) == len(n) == 0)
+                    continue
                 if with_ref_labels:
                     anchors, positives, negatives = (
                         embeddings[a],


### PR DESCRIPTION
I was experiencing a CUDA errors as weights from `DistanceWeightedMiner` were `weights.sum() == 0`.

This is just a miner fix to ensure weights can never occur, and fixes it by assigning a uniform weight in this edge case.