### PR TITLE
Crash early if faiss is not available

### DIFF
--- a/src/pytorch_metric_learning/utils/stat_utils.py
+++ b/src/pytorch_metric_learning/utils/stat_utils.py
@@ -7,6 +7,7 @@ except ModuleNotFoundError:
         """The pytorch-metric-learning testing module requires faiss. You can install the GPU version with the command 'conda install faiss-gpu -c pytorch' 
                         or the CPU version with 'conda install faiss-cpu -c pytorch'. Learn more at https://github.com/facebookresearch/faiss/blob/master/INSTALL.md"""
     )
+    raise
 
 # modified from https://github.com/facebookresearch/deepcluster
 def get_knn(


### PR DESCRIPTION
Since faiss is required, warning only enables the import of this module and delays crashing to some later stage. Might as well crash on import.