### PR TITLE
Fix MultiSimilarityMiner to support fp16 training

### DIFF
--- a/src/pytorch_metric_learning/miners/multi_similarity_miner.py
+++ b/src/pytorch_metric_learning/miners/multi_similarity_miner.py
@@ -11,7 +11,6 @@ class MultiSimilarityMiner(BaseTupleMiner):
         self.add_to_recordable_attributes(name="epsilon", is_stat=False)
 
     def mine(self, embeddings, labels, ref_emb, ref_labels):
-        dtype = embeddings.dtype
         mat = self.distance(embeddings, ref_emb)
         a1, p, a2, n = lmu.get_all_pairs_indices(labels, ref_labels)
 
@@ -22,6 +21,7 @@ class MultiSimilarityMiner(BaseTupleMiner):
         mat_neg_sorting = mat
         mat_pos_sorting = mat.clone()
 
+        dtype = mat.dtype
         pos_ignore = (
             c_f.pos_inf(dtype) if self.distance.is_inverted else c_f.neg_inf(dtype)
         )


### PR DESCRIPTION
Training fails when MultiSimilarityMiner is used with CosineSimilarity/DotProductSimilarity and fp16 (via autocast):
```
File "/home/lttazz99/miniconda3/envs/qna/lib/python3.7/site-packages/torch/nn/modules/module.py", line 722, in _call_impl
result = self.forward(*input, **kwargs)
File "/home/lttazz99/miniconda3/envs/qna/lib/python3.7/site-packages/pytorch_metric_learning/miners/base_miner.py", line 25, in forward
mining_output = self.mine(embeddings, labels, ref_emb, ref_labels)
File "/home/lttazz99/miniconda3/envs/qna/lib/python3.7/site-packages/pytorch_metric_learning/miners/multi_similarity_miner.py", line 28, in mine
mat_pos_sorting[a2, n] = pos_ignore
RuntimeError: value cannot be converted to type at::Half without overflow: 3.40282e+38
```

Both `embeddings` and `ref_emb` are float32, but returned `mat` has float16 dtype as a product of `torch.matmul` (in autocast). So the dtype of `mat` should be used when creating `pos_ignore` and `neg_ignore`.