### PR TITLE
Faster custom label comparison

### DIFF
--- a/src/pytorch_metric_learning/utils/accuracy_calculator.py
+++ b/src/pytorch_metric_learning/utils/accuracy_calculator.py
@@ -132,13 +132,10 @@ def get_label_match_counts(query_labels, reference_labels, label_comparison_fn):
     else:
         # Labels are compared with a custom function.
         # They might be non-categorical or multidimensional labels.
-        match_counts = np.array([0 for _ in unique_query_labels])
+        match_counts = np.empty(shape=(len(unique_query_labels)), dtype=int)
         for ix_a in range(len(unique_query_labels)):
             label_a = unique_query_labels[ix_a : ix_a + 1]
-            for ix_b in range(len(reference_labels)):
-                label_b = reference_labels[ix_b : ix_b + 1]
-                if label_comparison_fn(label_a, label_b):
-                    match_counts[ix_a] += 1
+            match_counts[ix_a] = sum(label_comparison_fn(label_a, reference_labels))
 
     # faiss can only do a max of k=1024, and we have to do k+1
     num_k = int(min(1023, np.max(match_counts)))
@@ -153,8 +150,8 @@ def get_lone_query_labels(
     label_comparison_fn,
 ):
     unique_labels, match_counts = label_counts
-    label_matches_itself = label_comparison_fn(unique_labels, unique_labels)
     if embeddings_come_from_same_source:
+        label_matches_itself = label_comparison_fn(unique_labels, unique_labels)
         lone_condition = match_counts - label_matches_itself <= 0
     else:
         lone_condition = match_counts == 0

--- a/src/pytorch_metric_learning/utils/accuracy_calculator.py
+++ b/src/pytorch_metric_learning/utils/accuracy_calculator.py
@@ -35,7 +35,7 @@ def get_relevance_mask(
     for label, count in zip(*label_counts):
         matching_rows = np.where(c_f.np_all_from_dim_to_end(gt_labels == label, 1))[0]
         max_column = count
-        if label_comparison_fn is EQUALITY and embeddings_come_from_same_source:
+        if embeddings_come_from_same_source:
             max_column -= 1
         relevance_mask[matching_rows, :max_column] = 1
     return relevance_mask

--- a/tests/utils/test_calculate_accuracies.py
+++ b/tests/utils/test_calculate_accuracies.py
@@ -519,9 +519,9 @@ class TestCalculateAccuraciesAndFaiss(unittest.TestCase):
             self.assertTrue(acc[k] == correct[k])
 
         correct = {
-            "precision_at_1": (1 + 1) / 2,
-            "r_precision": (3 / 3 + 2 / 3) / 2,
-            "mean_average_precision_at_r": (1 + (1 / 1 + 2 / 2 + 0) / 3) / 2,
+            "precision_at_1": 1.0,
+            "r_precision": 1.0,
+            "mean_average_precision_at_r": 1.0,
         }
         acc = AC_global_average.get_accuracy(
             query, reference, query_labels, reference_labels, True


### PR DESCRIPTION
Since the labels are numpy arrays, there's no need to loop over all labels. This can probably be even better if we expect the comparison function to be broadcastable (like np.equal), but this already helps a lot.

Added a new test case using floating point numbers that is easier to understand than the 2-dimensional ones.