### PR TITLE
modify the miner by annihilating the weight of same labels first

### DIFF
--- a/src/pytorch_metric_learning/miners/distance_weighted_miner.py
+++ b/src/pytorch_metric_learning/miners/distance_weighted_miner.py
@@ -43,7 +43,6 @@ class DistanceWeightedMiner(BaseTupleMiner):
         log_weights = log_weights * mask
         # Subtract max(log(distance)) for stability.
         weights = torch.exp(log_weights - torch.max(log_weights[~inf_or_nan]))
- 
 
         weights = weights * mask * ((mat < self.nonzero_loss_cutoff).type(dtype))
         weights[inf_or_nan] = 0

--- a/tests/miners/test_distance_weighted_miner.py
+++ b/tests/miners/test_distance_weighted_miner.py
@@ -35,6 +35,7 @@ class TestDistanceWeightedMiner(unittest.TestCase):
                 all_an_dist = torch.nn.functional.pairwise_distance(
                     embeddings[a], embeddings[n], 2
                 )
+            max_an_dist = torch.max(all_an_dist)
             min_an_dist = torch.min(all_an_dist)
 
             cutoffs = [0] + list(range(5, 15))
@@ -61,10 +62,11 @@ class TestDistanceWeightedMiner(unittest.TestCase):
                 self.assertTrue(torch.max(an_dist) <= non_zero_cutoff)
                 an_dist_var = torch.var(an_dist)
                 an_dist_mean = torch.mean(an_dist)
+                upper_bound = min(max_an_dist, non_zero_cutoff)
                 target_var = (
-                    (non_zero_cutoff - min_an_dist) ** 2
+                    (upper_bound - min_an_dist) ** 2
                 ) / 12  # variance formula for uniform distribution
-                target_mean = (non_zero_cutoff - min_an_dist) / 2
+                target_mean = (upper_bound + min_an_dist) / 2
                 self.assertTrue(torch.abs(an_dist_var - target_var) / target_var < 0.1)
                 self.assertTrue(
                     torch.abs(an_dist_mean - target_mean) / target_mean < 0.1


### PR DESCRIPTION
The distance of points from same class are small in general. The distance dominates the one of negative examples, so the weight of negative examples can become 0 due to arithmetical imprecision. Using the new miner, empirically the performances of models from previous miner and the new miner are similar.