### PR TITLE
Added UniformHistogramMiner

### DIFF
--- a/src/pytorch_metric_learning/miners/__init__.py
+++ b/src/pytorch_metric_learning/miners/__init__.py
@@ -9,3 +9,4 @@ from .maximum_loss_miner import MaximumLossMiner
 from .multi_similarity_miner import MultiSimilarityMiner
 from .pair_margin_miner import PairMarginMiner
 from .triplet_margin_miner import TripletMarginMiner
+from .uniform_histogram_miner import UniformHistogramMiner

--- a/src/pytorch_metric_learning/miners/uniform_histogram_miner.py
+++ b/src/pytorch_metric_learning/miners/uniform_histogram_miner.py
@@ -1,0 +1,67 @@
+import torch
+
+from ..utils import loss_and_miner_utils as lmu
+from .base_miner import BaseTupleMiner
+
+
+class UniformHistogramMiner(BaseTupleMiner):
+    def __init__(self, num_bins=100, pos_per_bin=10, neg_per_bin=10, **kwargs):
+        super().__init__(**kwargs)
+        self.num_bins = num_bins
+        self.pos_per_bin = pos_per_bin
+        self.neg_per_bin = neg_per_bin
+        self.add_to_recordable_attributes(
+            list_of_names=["pos_per_bin", "neg_per_bin"], is_stat=False
+        )
+
+    def mine(self, embeddings, labels, ref_emb, ref_labels):
+        dtype = embeddings.dtype
+        mat = self.distance(embeddings, ref_emb)
+        a1, p, a2, n = lmu.get_all_pairs_indices(labels, ref_labels)
+        pos_pairs = mat[a1, p]
+        neg_pairs = mat[a2, n]
+
+        if len(pos_pairs) > 0:
+            a1, p = self.get_uniformly_distributed_pairs(
+                pos_pairs, a1, p, self.pos_per_bin
+            )
+
+        if len(neg_pairs) > 0:
+            a2, n = self.get_uniformly_distributed_pairs(
+                neg_pairs, a2, n, self.neg_per_bin
+            )
+
+        return a1, p, a2, n
+
+    def get_bins(self, pairs):
+        device, dtype = pairs.device, pairs.dtype
+        return torch.linspace(
+            torch.min(pairs),
+            torch.max(pairs),
+            steps=self.num_bins + 1,
+            device=device,
+            dtype=dtype,
+        )
+
+    def filter_by_bin(self, distances, bins, num_pairs):
+        range_max = len(bins) - 1
+        all_idx = []
+        for i in range(range_max):
+            s, e = bins[i], bins[i + 1]
+            low_condition = s <= distances
+            high_condition = distances < e if i != range_max - 1 else distances <= e
+            condition = torch.where(low_condition & high_condition)[0]
+            if len(condition) == 0:
+                continue
+            idx = torch.multinomial(
+                torch.ones_like(condition, device=condition.device, dtype=torch.float),
+                num_pairs,
+                replacement=True,
+            )
+            all_idx.append(condition[idx])
+        return torch.cat(all_idx, dim=0)
+
+    def get_uniformly_distributed_pairs(self, distances, anchors, others, num_pairs):
+        bins = self.get_bins(distances)
+        idx = self.filter_by_bin(distances, bins, num_pairs)
+        return anchors[idx], others[idx]

--- a/tests/miners/test_uniform_histogram_miner.py
+++ b/tests/miners/test_uniform_histogram_miner.py
@@ -1,0 +1,72 @@
+import unittest
+
+import torch
+
+from pytorch_metric_learning.distances import LpDistance, SNRDistance
+from pytorch_metric_learning.miners import UniformHistogramMiner
+from pytorch_metric_learning.utils import loss_and_miner_utils as lmu
+
+from .. import TEST_DEVICE, TEST_DTYPES
+
+
+class TestUniformHistogramMiner(unittest.TestCase):
+    def test_uniform_histogram_miner(self):
+        batch_size = 128
+        embedding_size = 32
+        num_bins, pos_per_bin, neg_per_bin = 100, 25, 123
+        for distance in [
+            LpDistance(p=1),
+            LpDistance(p=2),
+            LpDistance(normalize_embeddings=False),
+            SNRDistance(),
+        ]:
+            miner = UniformHistogramMiner(
+                num_bins=num_bins,
+                pos_per_bin=pos_per_bin,
+                neg_per_bin=neg_per_bin,
+                distance=distance,
+            )
+            for dtype in TEST_DTYPES:
+                embeddings = torch.randn(
+                    batch_size, embedding_size, device=TEST_DEVICE, dtype=dtype
+                )
+                labels = torch.randint(0, 2, size=(batch_size,), device=TEST_DEVICE)
+
+                a1, p, a2, n = lmu.get_all_pairs_indices(labels)
+                dist_mat = distance(embeddings)
+                pos_pairs = dist_mat[a1, p]
+                neg_pairs = dist_mat[a2, n]
+
+                a1, p, a2, n = miner(embeddings, labels)
+
+                if dtype == torch.float16:
+                    continue  # histc doesn't work for Half tensor
+
+                pos_histogram = torch.histc(
+                    dist_mat[a1, p],
+                    bins=num_bins,
+                    min=torch.min(pos_pairs),
+                    max=torch.max(pos_pairs),
+                )
+                neg_histogram = torch.histc(
+                    dist_mat[a2, n],
+                    bins=num_bins,
+                    min=torch.min(neg_pairs),
+                    max=torch.max(neg_pairs),
+                )
+
+                self.assertTrue(
+                    torch.all((pos_histogram == pos_per_bin) | (pos_histogram == 0))
+                )
+                self.assertTrue(
+                    torch.all((neg_histogram == neg_per_bin) | (neg_histogram == 0))
+                )
+
+    def test_no_positives(self):
+        miner = UniformHistogramMiner()
+        batch_size = 32
+        for dtype in TEST_DTYPES:
+            embeddings = torch.randn(batch_size, 64).type(dtype).to(TEST_DEVICE)
+            labels = torch.arange(batch_size)
+            a1, p, _, _ = miner(embeddings, labels)
+            self.assertTrue(len(a1) == len(p) == 0)


### PR DESCRIPTION
Example usage:
```python
from pytorch_metric_learning.miners import UniformHistogramMiner
from pytorch_metric_learning.distances import SNRDistance

miner = UniformHistogramMiner(
    num_bins=100,
    pos_per_bin=25,
    neg_per_bin=33,
    distance=SNRDistance(),
)
```

In a given batch, this will:
- Divide up the positive distances into 100 bins, and return 25 positive pairs per bin, or 0 if no pairs exist in that bin
- Divide up the negative distances into 100 bins, and return 33 negative pairs per bin, or 0 if no pairs exist in that bin

This is like ```DistanceWeightedMiner```, except that it works well with high dimension embeddings, and works with any distance metric (not just L2 normalized distance).