### PR TITLE
Mean Reciprocal Rank (mRR) inclusion to default metrics in AccuracyCalculator

### DIFF
--- a/docs/accuracy_calculation.md
+++ b/docs/accuracy_calculation.md
@@ -59,6 +59,7 @@ def get_accuracy(self,
 # "precision_at_1"
 # "r_precision"
 # "mean_average_precision_at_r"
+# "mean_reciprocal_rank"
 ```
 
 * **query**: A 2D torch or numpy array of size ```(Nq, D)```, where Nq is the number of query samples. For each query sample, nearest neighbors are retrieved and accuracy is computed.
@@ -96,6 +97,9 @@ If your dataset is large, you might find the k-nn search is very slow. This is b
 
     - [Slides from Stanford](https://web.stanford.edu/class/cs276/handouts/EvaluationNew-handout-1-per.pdf)
 
+- **mean_reciprocal_rank**:
+
+    - [Slides from Stanford](https://web.stanford.edu/class/cs276/handouts/EvaluationNew-handout-1-per.pdf)
 - **mean_average_precision_at_r**:
 
     - [See section 3.2 of A Metric Learning Reality Check](https://arxiv.org/pdf/2003.08505.pdf)

--- a/tests/utils/test_calculate_accuracies.py
+++ b/tests/utils/test_calculate_accuracies.py
@@ -68,6 +68,7 @@ class TestCalculateAccuracies(unittest.TestCase):
                         self.assertTrue(acc["r_precision"] == 0)
                         self.assertTrue(acc["mean_average_precision_at_r"] == 0)
                         self.assertTrue(acc["mean_average_precision"] == 0)
+                        self.assertTrue(acc["mean_reciprocal_rank"] == 0)
                     else:
                         self.assertTrue(
                             isclose(
@@ -95,7 +96,13 @@ class TestCalculateAccuracies(unittest.TestCase):
                                 self.correct_mean_average_precision(ecfss, avg_of_avgs),
                             )
                         )
-
+                        print("mrr", self.correct_mean_reciprocal_rank(ecfss, avg_of_avgs),)
+                        self.assertTrue(
+                            isclose(
+                                acc["mean_reciprocal_rank"],
+                                self.correct_mean_reciprocal_rank(ecfss, avg_of_avgs),
+                            )
+                        )
     def correct_precision_at_1(self, embeddings_come_from_same_source, avg_of_avgs):
         if not embeddings_come_from_same_source:
             if not avg_of_avgs:
@@ -161,6 +168,21 @@ class TestCalculateAccuracies(unittest.TestCase):
             acc2 = 1.0 / 4
             acc3 = (1.0 / 2 + 2.0 / 4) / 2
             acc4 = 1.0 / 2
+        if not avg_of_avgs:
+            return np.mean([acc0, acc1, acc2, acc3, acc4])
+        else:
+            return np.mean([(acc0 + acc1) / 2, acc2, acc3, acc4])
+            
+    def correct_mean_reciprocal_rank(
+        self, embeddings_come_from_same_source, avg_of_avgs
+    ):
+        # doesnt matter whether embeddings_come_from_same_source
+        acc0 = 1/2
+        acc1 = 1
+        acc2 = 1/5
+        acc3 = 1
+        acc4 = 1/3
+        
         if not avg_of_avgs:
             return np.mean([acc0, acc1, acc2, acc3, acc4])
         else:

--- a/tests/utils/test_calculate_accuracies.py
+++ b/tests/utils/test_calculate_accuracies.py
@@ -96,7 +96,6 @@ class TestCalculateAccuracies(unittest.TestCase):
                                 self.correct_mean_average_precision(ecfss, avg_of_avgs),
                             )
                         )
-                        print("mrr", self.correct_mean_reciprocal_rank(ecfss, avg_of_avgs),)
                         self.assertTrue(
                             isclose(
                                 acc["mean_reciprocal_rank"],
@@ -177,12 +176,19 @@ class TestCalculateAccuracies(unittest.TestCase):
         self, embeddings_come_from_same_source, avg_of_avgs
     ):
         # doesnt matter whether embeddings_come_from_same_source
-        acc0 = 1/2
-        acc1 = 1
-        acc2 = 1/5
-        acc3 = 1
-        acc4 = 1/3
-        
+        if not embeddings_come_from_same_source:
+            acc0 = 1/2
+            acc1 = 1
+            acc2 = 1/5
+            acc3 = 1
+            acc4 = 1/3
+        else:
+            acc0 = 1
+            acc1 = 1/2
+            acc2 = 1/4
+            acc3 = 1/2
+            acc4 = 1/2
+
         if not avg_of_avgs:
             return np.mean([acc0, acc1, acc2, acc3, acc4])
         else:


### PR DESCRIPTION
Solves #369 

mRR is a pretty standard statistic in retrieval related research and believed this to be an appropriate metric to be included in the default accuracy metrics.

The reason why I had made a request before and closed it is because it didn't fulfill the following test:

```TEST_DTYPES=float32,float64 TEST_DEVICE=cpu WITH_COLLECT_STATS=false python -m unittest discover -t . -s tests/utils```

Since `isclose()` is defined as the following in `test_accuracy_calculator.py`:
```python
def isclose(x, y):
    rtol = 0
    if TEST_DEVICE == torch.device("cpu"):
        atol = 1e-15
    else:
        atol = 1e-7
    return np.isclose(x, y, atol=atol, rtol=rtol)
```

And the code below:
```python
print("acc", acc["mean_reciprocal_rank"]) #
print("mrr", self.correct_mean_reciprocal_rank(ecfss, avg_of_avgs))
self.assertTrue(
    isclose(
        acc["mean_reciprocal_rank"],
        self.correct_mean_reciprocal_rank(ecfss, avg_of_avgs),
    )
)
```
returns:
```
acc 0.6066666841506958
mrr 0.6066666666666667
```

Was there a specific reason why the error term for cpu is much stricter? It does pass for the GPU case. Does this level of error indicate actually something wrong in my code?




