### PR TITLE
Mean Reciprocal Rank (mRR) inclusion to default metrics in AccuracyCalculator

### DIFF
--- a/src/pytorch_metric_learning/__init__.py
+++ b/src/pytorch_metric_learning/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.0.dev0"
+__version__ = "1.1.0.dev1"

--- a/src/pytorch_metric_learning/utils/accuracy_calculator.py
+++ b/src/pytorch_metric_learning/utils/accuracy_calculator.py
@@ -113,6 +113,34 @@ def mean_average_precision(
         accuracy_per_sample, gt_labels, avg_of_avgs, return_per_class
     )
 
+def mean_reciprocal_rank(
+    knn_labels,
+    gt_labels,
+    embeddings_come_from_same_source,
+    avg_of_avgs,
+    return_per_class,
+    label_comparison_fn,
+    relevance_mask=None,
+    at_r=False,
+):
+    device = gt_labels.device
+    num_samples, num_k = knn_labels.shape[:2]
+
+    is_same_label = label_comparison_fn(gt_labels, knn_labels)
+
+    # find & remove caeses where it has 0 correct results
+    sum_per_row = is_same_label.sum(-1)
+    zero_remove_mask = sum_per_row > 0
+    indices = torch.arange(is_same_label.shape[1], 0, -1).to(device)
+    tmp = is_same_label * indices
+    indices = torch.argmax(tmp, 1, keepdim=True) + 1.0
+    
+    indices[zero_remove_mask] = 1. / indices[zero_remove_mask]
+    indices[~zero_remove_mask] = 0.
+
+    indices = indices.flatten()
+
+    return maybe_get_avg_of_avgs(indices, gt_labels, avg_of_avgs, return_per_class)
 
 def mean_average_precision_at_r(
     knn_labels,
@@ -365,6 +393,30 @@ class AccuracyCalculator:
             return zero_accuracy(label_counts[0], self.return_per_class)
 
         return mean_average_precision(
+            knn_labels,
+            query_labels[:, None],
+            embeddings_come_from_same_source,
+            self.avg_of_avgs,
+            self.return_per_class,
+            self.label_comparison_fn,
+        )
+
+    def calculate_mean_reciprocal_rank(
+        self,
+        knn_labels,
+        query_labels,
+        not_lone_query_mask,
+        embeddings_come_from_same_source,
+        label_counts,
+        **kwargs,
+    ):
+        knn_labels, query_labels = try_getting_not_lone_labels(
+            knn_labels, query_labels, not_lone_query_mask
+        )
+        if knn_labels is None:
+            return zero_accuracy(label_counts[0], self.return_per_class)
+
+        return mean_reciprocal_rank(
             knn_labels,
             query_labels[:, None],
             embeddings_come_from_same_source,

--- a/tests/utils/test_calculate_accuracies.py
+++ b/tests/utils/test_calculate_accuracies.py
@@ -124,6 +124,15 @@ class TestCalculateAccuracies(unittest.TestCase):
                                     many=return_per_class,
                                 )
                             )
+                            self.assertTrue(
+                            isclose(
+                                acc["mean_reciprocal_rank"],
+                                self.correct_mean_reciprocal_rank(
+                                    ecfss, avg_of_avgs, return_per_class
+                                ),
+                                many=return_per_class,
+                            )
+                        )
 
     def correct_precision_at_1(
         self, embeddings_come_from_same_source, avg_of_avgs, return_per_class
@@ -203,6 +212,31 @@ class TestCalculateAccuracies(unittest.TestCase):
             acc2 = 1.0 / 4
             acc3 = (1.0 / 2 + 2.0 / 4) / 2
             acc4 = 1.0 / 2
+        accs = [(acc0 + acc1) / 2, acc2, acc3, acc4]
+        if avg_of_avgs:
+            return np.mean(accs)
+        elif return_per_class:
+            return accs
+        else:
+            return np.mean([acc0, acc1, acc2, acc3, acc4])
+
+    def correct_mean_reciprocal_rank(
+        self, embeddings_come_from_same_source, avg_of_avgs, return_per_class
+    ):
+        # doesnt matter whether embeddings_come_from_same_source
+        if not embeddings_come_from_same_source:
+            acc0 = 1/2
+            acc1 = 1
+            acc2 = 1/5
+            acc3 = 1
+            acc4 = 1/3
+        else:
+            acc0 = 1
+            acc1 = 1/2
+            acc2 = 1/4
+            acc3 = 1/2
+            acc4 = 1/2
+
         accs = [(acc0 + acc1) / 2, acc2, acc3, acc4]
         if avg_of_avgs:
             return np.mean(accs)

--- a/tests/utils/test_calculate_accuracies.py
+++ b/tests/utils/test_calculate_accuracies.py
@@ -12,11 +12,8 @@ from .. import TEST_DEVICE
 
 
 def isclose(x, y, many=False):
-    rtol = 0
-    if TEST_DEVICE == torch.device("cpu"):
-        atol = 1e-15
-    else:
-        atol = 1e-7
+    rtol = 1e-6
+    atol = 0
     if many:
         return np.allclose(x, y, atol=atol, rtol=rtol)
     return np.isclose(x, y, atol=atol, rtol=rtol)
@@ -24,7 +21,7 @@ def isclose(x, y, many=False):
 
 class TestCalculateAccuracies(unittest.TestCase):
     def test_accuracy_calculator(self):
-        query_labels = torch.tensor([1, 1, 2, 3, 4], device=TEST_DEVICE)
+        query_labels = torch.tensor([1, 1, 2, 3, 4, 0], device=TEST_DEVICE)
 
         knn_labels1 = torch.tensor(
             [
@@ -33,13 +30,14 @@ class TestCalculateAccuracies(unittest.TestCase):
                 [4, 4, 4, 4, 2],
                 [3, 1, 3, 1, 3],
                 [0, 0, 4, 2, 2],
+                [1, 2, 3, 4, 5],
             ],
             device=TEST_DEVICE,
         )
-        label_counts1 = ([1, 2, 3, 4], [3, 5, 4, 5])
+        label_counts1 = ([0, 1, 2, 3, 4], [2, 3, 5, 4, 5])
 
         knn_labels2 = knn_labels1 + 5
-        label_counts2 = ([6, 7, 8, 9], [3, 5, 4, 5])
+        label_counts2 = ([5, 6, 7, 8, 9], [2, 3, 5, 4, 5])
 
         for avg_of_avgs in [False, True]:
             for return_per_class in [False, True]:
@@ -67,9 +65,9 @@ class TestCalculateAccuracies(unittest.TestCase):
                         "query_labels": query_labels,
                         "label_counts": label_counts,
                         "knn_labels": knn_labels,
-                        "not_lone_query_mask": torch.ones(5, dtype=torch.bool)
+                        "not_lone_query_mask": torch.ones(6, dtype=torch.bool)
                         if i == 0
-                        else torch.zeros(5, dtype=torch.bool),
+                        else torch.zeros(6, dtype=torch.bool),
                     }
 
                     function_dict = AC.get_function_dict()
@@ -80,13 +78,14 @@ class TestCalculateAccuracies(unittest.TestCase):
                         kwargs["embeddings_come_from_same_source"] = ecfss
                         acc = AC._get_accuracy(function_dict, **kwargs)
                         if i == 1:
-                            zero_acc = 0 if not return_per_class else [0, 0, 0, 0]
+                            zero_acc = 0 if not return_per_class else [0, 0, 0, 0, 0]
                             self.assertTrue(acc["precision_at_1"] == zero_acc)
                             self.assertTrue(acc["r_precision"] == zero_acc)
                             self.assertTrue(
                                 acc["mean_average_precision_at_r"] == zero_acc
                             )
                             self.assertTrue(acc["mean_average_precision"] == zero_acc)
+                            self.assertTrue(acc["mean_reciprocal_rank"] == zero_acc)
                         else:
                             self.assertTrue(
                                 isclose(
@@ -125,26 +124,26 @@ class TestCalculateAccuracies(unittest.TestCase):
                                 )
                             )
                             self.assertTrue(
-                            isclose(
-                                acc["mean_reciprocal_rank"],
-                                self.correct_mean_reciprocal_rank(
-                                    ecfss, avg_of_avgs, return_per_class
-                                ),
-                                many=return_per_class,
+                                isclose(
+                                    acc["mean_reciprocal_rank"],
+                                    self.correct_mean_reciprocal_rank(
+                                        ecfss, avg_of_avgs, return_per_class
+                                    ),
+                                    many=return_per_class,
+                                )
                             )
-                        )
 
     def correct_precision_at_1(
         self, embeddings_come_from_same_source, avg_of_avgs, return_per_class
     ):
         if not embeddings_come_from_same_source:
-            accs = [0.5, 0, 1, 0]
+            accs = [0, 0.5, 0, 1, 0]
             if not (avg_of_avgs or return_per_class):
-                return 0.4
+                return 2.0 / 6
         else:
-            accs = [0.5, 0, 0, 0]
+            accs = [0, 0.5, 0, 0, 0]
             if not (avg_of_avgs or return_per_class):
-                return 0.2
+                return 1.0 / 6
 
         if avg_of_avgs:
             return np.mean(accs)
@@ -160,19 +159,21 @@ class TestCalculateAccuracies(unittest.TestCase):
             acc2 = 1.0 / 5
             acc3 = 2.0 / 4
             acc4 = 1.0 / 5
+            acc5 = 0
         else:
             acc0 = 1.0 / 1
             acc1 = 1.0 / 2
             acc2 = 1.0 / 4
             acc3 = 1.0 / 3
             acc4 = 1.0 / 4
-        accs = [(acc0 + acc1) / 2, acc2, acc3, acc4]
+            acc5 = 0
+        accs = [acc5, (acc0 + acc1) / 2, acc2, acc3, acc4]
         if avg_of_avgs:
             return np.mean(accs)
         elif return_per_class:
             return accs
         else:
-            return np.mean([acc0, acc1, acc2, acc3, acc4])
+            return np.mean([acc0, acc1, acc2, acc3, acc4, acc5])
 
     def correct_mean_average_precision_at_r(
         self, embeddings_come_from_same_source, avg_of_avgs, return_per_class
@@ -183,19 +184,21 @@ class TestCalculateAccuracies(unittest.TestCase):
             acc2 = (1.0 / 5) / 5
             acc3 = (1 + 2.0 / 3) / 4
             acc4 = (1.0 / 3) / 5
+            acc5 = 0
         else:
             acc0 = 1
             acc1 = (1.0 / 2) / 2
             acc2 = (1.0 / 4) / 4
             acc3 = (1.0 / 2) / 3
             acc4 = (1.0 / 2) / 4
-        accs = [(acc0 + acc1) / 2, acc2, acc3, acc4]
+            acc5 = 0
+        accs = [acc5, (acc0 + acc1) / 2, acc2, acc3, acc4]
         if avg_of_avgs:
             return np.mean(accs)
         elif return_per_class:
             return accs
         else:
-            return np.mean([acc0, acc1, acc2, acc3, acc4])
+            return np.mean([acc0, acc1, acc2, acc3, acc4, acc5])
 
     def correct_mean_average_precision(
         self, embeddings_come_from_same_source, avg_of_avgs, return_per_class
@@ -206,44 +209,47 @@ class TestCalculateAccuracies(unittest.TestCase):
             acc2 = (1.0 / 5) / 1
             acc3 = (1 + 2.0 / 3 + 3.0 / 5) / 3
             acc4 = (1.0 / 3) / 1
+            acc5 = 0
         else:
             acc0 = 1
             acc1 = (1.0 / 2 + 2.0 / 3) / 2
             acc2 = 1.0 / 4
             acc3 = (1.0 / 2 + 2.0 / 4) / 2
             acc4 = 1.0 / 2
-        accs = [(acc0 + acc1) / 2, acc2, acc3, acc4]
+            acc5 = 0
+        accs = [acc5, (acc0 + acc1) / 2, acc2, acc3, acc4]
         if avg_of_avgs:
             return np.mean(accs)
         elif return_per_class:
             return accs
         else:
-            return np.mean([acc0, acc1, acc2, acc3, acc4])
+            return np.mean([acc0, acc1, acc2, acc3, acc4, acc5])
 
     def correct_mean_reciprocal_rank(
         self, embeddings_come_from_same_source, avg_of_avgs, return_per_class
     ):
-        # doesnt matter whether embeddings_come_from_same_source
         if not embeddings_come_from_same_source:
-            acc0 = 1/2
+            acc0 = 1 / 2
             acc1 = 1
-            acc2 = 1/5
+            acc2 = 1 / 5
             acc3 = 1
-            acc4 = 1/3
+            acc4 = 1 / 3
+            acc5 = 0
         else:
             acc0 = 1
-            acc1 = 1/2
-            acc2 = 1/4
-            acc3 = 1/2
-            acc4 = 1/2
+            acc1 = 1 / 2
+            acc2 = 1 / 4
+            acc3 = 1 / 2
+            acc4 = 1 / 2
+            acc5 = 0
 
-        accs = [(acc0 + acc1) / 2, acc2, acc3, acc4]
+        accs = [acc5, (acc0 + acc1) / 2, acc2, acc3, acc4]
         if avg_of_avgs:
             return np.mean(accs)
         elif return_per_class:
             return accs
         else:
-            return np.mean([acc0, acc1, acc2, acc3, acc4])
+            return np.mean([acc0, acc1, acc2, acc3, acc4, acc5])
 
     def test_get_lone_query_labels_custom(self):
         def fn1(x, y):


### PR DESCRIPTION
Solves #369

mRR is a pretty standard statistic in retrieval related research and believed this to be an appropriate metric to be included in the default accuracy metrics.

The reason why I had made a request before and closed it is because it didn't fulfill the following test:

`TEST_DTYPES=float32,float64 TEST_DEVICE=cpu WITH_COLLECT_STATS=false python -m unittest discover -t . -s tests/utils`

Since `isclose()` is defined as the following in `test_accuracy_calculator.py`:

```python
def isclose(x, y):
    rtol = 0
    if TEST_DEVICE == torch.device("cpu"):
        atol = 1e-15
    else:
        atol = 1e-7
    return np.isclose(x, y, atol=atol, rtol=rtol)
```

And the code below:
```python
print("acc", acc["mean_reciprocal_rank"]) #
print("mrr", self.correct_mean_reciprocal_rank(ecfss, avg_of_avgs))
self.assertTrue(
    isclose(
        acc["mean_reciprocal_rank"],
        self.correct_mean_reciprocal_rank(ecfss, avg_of_avgs),
    )
)
```
returns:
```
acc 0.6066666841506958
mrr 0.6066666666666667
```
Was there a specific reason why the error term for cpu is much stricter? It does pass for the GPU case. Does this level of error indicate actually something wrong in my code?

p.s. sorry for the mess with making multiple pull requests - turns out I hadn't properly pulled the commits from the dev branch.