### PR TITLE
Add ValueError, Additional Documentation & Code Comments to CentroidTripletLos

### DIFF
--- a/docs/losses.md
+++ b/docs/losses.md
@@ -164,6 +164,21 @@ losses.CentroidTripletLoss(margin=0.05,
                             triplets_per_anchor="all",
                             **kwargs)
 ```
+
+Unlike many other losses, the instance of this class can only be called as the following:
+
+```python
+from pytorch_metric_learning import losses
+loss_func = losses.SomeLoss()
+
+embeddings = torch.randn(8, 32)
+labels = torch.tensor([0, 0, 0, 0, 0, 0, 1, 1])
+loss = loss_func(embeddings, labels) 
+```
+
+and does not allow for use of `ref_embs`, `ref_labels`. Furthermore, the labels can't imply classes with just one 
+embedding in it (e.g. if there was only one label with value `1` in the above example). Refer to a [previous issue](https://github.com/KevinMusgrave/pytorch-metric-learning/issues/451) about this topic.
+
 **Parameters**:
 
 See [TripletMarginLoss](losses.md#tripletmarginloss)

--- a/src/pytorch_metric_learning/losses/centroid_triplet_loss.py
+++ b/src/pytorch_metric_learning/losses/centroid_triplet_loss.py
@@ -43,8 +43,8 @@ class CentroidTripletLoss(BaseMetricLossFunction):
         """
         masks, class_masks, labels_list, query_indices = self.create_masks_train(labels)
 
-        P = len(labels_list)
-        M = max([len(instances) for instances in labels_list])
+        P = len(labels_list) # number of classes
+        M = max([len(instances) for instances in labels_list]) # max number of samples per class
         DIM = embeddings.size(-1)
 
         """
@@ -60,6 +60,7 @@ class CentroidTripletLoss(BaseMetricLossFunction):
                 centroids_emb[M+1] == centroid vector for 1th class, where the first embedding is the query vector
         """
 
+        # masks, class_masks but 1.0 for True and 0.0 for False, for counting purposes.
         masks_float = masks.type(embeddings.type()).to(embeddings.device)
         class_masks_float = class_masks.type(embeddings.type()).to(embeddings.device)
         inst_counts = masks_float.sum(-1)
@@ -94,13 +95,23 @@ class CentroidTripletLoss(BaseMetricLossFunction):
         embeddings_collect = []
         tuple_indices_collect = []
         starting_idx = 0
+
+        '''
+        valid_mask[i][j] is True if jth class has an ith sample.
+        Example: [0, 0, 1, 1, 1, 2, 2, 3]
+        valid_mask= [
+                        [ True,  True,  True, True],
+                        [ True,  True,  True, False],
+                        [False,  True, False, False]
+                    ]
+        '''
         for inst_idx in range(M):
             one_mask = valid_mask[inst_idx]
             if torch.sum(one_mask) > 1:
                 anchors = query_embeddings[inst_idx][one_mask]
                 pos_centroids = positive_centroids_emb[inst_idx][one_mask]
                 one_labels = query_labels[inst_idx][one_mask]
-
+            
                 embeddings_concat = torch.cat(
                     (anchors, pos_centroids, negative_centroids_emb)
                 )
@@ -118,6 +129,7 @@ class CentroidTripletLoss(BaseMetricLossFunction):
                 3. negative as so
                 """
                 # make only query vectors be anchor vectors
+
                 indices_tuple = [x[: len(x) // 3] + starting_idx for x in indices_tuple]
 
                 # make only pos_centroids be postive examples
@@ -148,6 +160,24 @@ class CentroidTripletLoss(BaseMetricLossFunction):
         return loss
 
     def create_masks_train(self, class_labels):
+        '''Create masks for indexing embeddings and labels.
+
+        Args:
+            class_labels (`torch.Tensor`): Labels for embeddings. (e.g. [0, 0, 1, 1, 1, 2, 2, 3])
+        
+        Returns:
+            labels_list (`list`): an organized index of class_labels, where labels_list[i] == list of indices
+                for class i corresponding to class_labels. Example (for labels in Args documentation): `[[0, 1], [2, 3, 4], [5, 6], [7]]`
+            query_indices (`list`): a "foldable", extended version of `labels_list`. Length of query_indices is equal to `len(labels_list) * max([len(i) for i in labels_list]`.
+                For imbalanced labels, it fills with 0: `[0, 1, 0, 2, 3, 4, 5, 6, 0, 7, 0, 0]`
+            masks (`torch.Tensor`): A masking matrix corresponding to `query_indices`, where `len(masks)==len(class_labels)` and `len(masks[0])==len(query_indices)`.
+                `masks[i][j]` is `True` if `query_labels[i]` and `class_labels[j]` are in the same class, `False` otherwise.
+                This is used later where `masks[i]` if a boolean mask over the input embeddings that retrieves those of the same
+                class as the ith embedding.
+            class_masks (`torch.Tensor`): A mask for indexing same-class embeddings. `class_masks[i]` is a boolean row whose values are `True` for input embeddings
+                that belong in class `i`.
+
+        '''
         labels_dict = defaultdict(list)
         class_labels = class_labels.detach().cpu().numpy()
         for idx, pid in enumerate(class_labels):
@@ -156,6 +186,12 @@ class CentroidTripletLoss(BaseMetricLossFunction):
         unique_classes = list(labels_dict.keys())
         labels_list = list(labels_dict.values())
         lens_list = [len(item) for item in labels_list]
+
+        if min(lens_list) <= 1:
+            raise ValueError(
+                'The input embeddings and labels such be that it implies no class '
+                f'with just one embedding as member but is {class_labels}. '
+                'Refer to the documentation at https://kevinmusgrave.github.io/pytorch-metric-learning/losses/#centroidtripletloss for more details.')
         lens_list_cs = np.cumsum(lens_list)
 
         M = max(len(instances) for instances in labels_list)
@@ -171,9 +207,11 @@ class CentroidTripletLoss(BaseMetricLossFunction):
                 if instance_idx < len(class_insts):
                     query_indices.append(class_insts[instance_idx])
                     ones = class_insts[:instance_idx] + class_insts[instance_idx + 1 :]
+                    # ones = class_insts
                     masks[matrix_idx, ones] = 1
                 else:
                     query_indices.append(0)
+
         return masks, class_masks, labels_list, query_indices
 
     def get_default_reducer(self):

--- a/tests/losses/test_centroid_triplet_loss.py
+++ b/tests/losses/test_centroid_triplet_loss.py
@@ -19,9 +19,11 @@ def normalize(embeddings):
 class TestCentroidTripletLoss(unittest.TestCase):
     def test_indices_tuple_failure(self):
         loss_fn = CentroidTripletLoss()
-        embeddings = torch.randn(8, 32, device=TEST_DEVICE)
-        labels = torch.tensor([0, 0, 1, 1, 1, 2, 2, 3], device=TEST_DEVICE)
-        loss_fn(embeddings, labels)
+        embeddings = torch.randn(9, 32, device=TEST_DEVICE)
+        labels = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 1], device=TEST_DEVICE)
+
+        with self.assertRaises(ValueError) as context:
+            loss_fn(embeddings, labels)
 
     def test_centroid_triplet_loss(self):
         for dtype in TEST_DTYPES:


### PR DESCRIPTION
Fixes #451 , adding an explicit check for classes with just one embeddings, and specifying this restriction to the documentation.

Added extra code comments to improve readability.