### PR TITLE
fixes #467

### DIFF
--- a/src/pytorch_metric_learning/losses/vicreg_loss.py
+++ b/src/pytorch_metric_learning/losses/vicreg_loss.py
@@ -70,12 +70,14 @@ class VICRegLoss(BaseMetricLossFunction):
     def variance_loss(self, emb, ref_emb):
         std_emb = torch.sqrt(emb.var(dim=0) + self.eps)
         std_ref_emb = torch.sqrt(ref_emb.var(dim=0) + self.eps)
-        return F.relu(1 - std_emb), F.relu(1 - std_ref_emb)
+        return F.relu(1 - std_emb) / 2, F.relu(1 - std_ref_emb) / 2 # / 2 for averaging
 
     def covariance_loss(self, emb, ref_emb):
-        _, D = emb.size()
-        cov_emb = torch.cov(emb.T)
-        cov_ref_emb = torch.cov(ref_emb.T)
+        N, D = emb.size()
+        emb = emb - emb.mean(dim=0)
+        ref_emb = ref_emb - ref_emb.mean(dim=0)
+        cov_emb = (emb.T @ emb) / (N - 1)
+        cov_ref_emb = (ref_emb.T @ ref_emb) / (N - 1)
 
         diag = torch.eye(D, device=cov_emb.device)
         cov_loss = (

--- a/tests/losses/test_vicreg_loss.py
+++ b/tests/losses/test_vicreg_loss.py
@@ -42,6 +42,7 @@ class TestVICRegLoss(unittest.TestCase):
                     variance_loss = torch.mean(F.relu(1 - std_emb)) + torch.mean(
                         F.relu(1 - std_ref_emb)
                     )
+                    variance_loss = variance_loss / 2 # for averaging
 
                     # covariance loss, a more manual version
                     N, D = emb.size()


### PR DESCRIPTION
Fixes #467 

Changes the vicreg loss into the more manual version that doesnt require a high level of pytorch
Previously did mean(var1) + mean(var2), changed to that sum / 2 since that'd be the actual average