### PR TITLE
add compatibility of distributedwrapper for two stream input

### DIFF
--- a/src/pytorch_metric_learning/utils/distributed.py
+++ b/src/pytorch_metric_learning/utils/distributed.py
@@ -25,23 +25,32 @@ def all_gather(x):
 
 
 # modified from https://github.com/JohnGiorgi/DeCLUTR
-def all_gather_embeddings_and_labels(embeddings, labels):
+def all_gather_embeddings_and_labels(emb, labels):
     # If we are not using distributed training, this is a no-op.
     if not is_distributed():
         return None, None
-    ref_emb = all_gather(embeddings)
+    ref_emb = all_gather(emb)
     ref_labels = all_gather(labels)
     return ref_emb, ref_labels
 
 
-def gather(embeddings, labels):
-    device = embeddings.device
+def gather(emb, labels, ref_emb=None, ref_labels=None):
+    device = emb.device
     labels = c_f.to_device(labels, device=device)
     rank = torch.distributed.get_rank()
-    dist_ref_emb, dist_ref_labels = all_gather_embeddings_and_labels(embeddings, labels)
-    all_emb = torch.cat([embeddings, dist_ref_emb], dim=0)
-    all_labels = torch.cat([labels, dist_ref_labels], dim=0)
-    return all_emb, all_labels, labels, device
+
+    dist_emb, dist_labels = all_gather_embeddings_and_labels(emb, labels)
+    all_emb = torch.cat([emb, dist_emb], dim=0)
+    all_labels = torch.cat([labels, dist_labels], dim=0)
+
+    if ref_emb != None and ref_labels != None:
+        dist_ref_emb, dist_ref_labels = all_gather_embeddings_and_labels(ref_emb, ref_labels)
+        all_ref_emb = torch.cat([ref_emb, dist_ref_emb], dim=0)
+        all_ref_labels = torch.cat([ref_labels, dist_ref_labels], dim=0)
+    else:
+        all_ref_emb, all_ref_labels = None, None
+
+    return all_emb, all_labels, all_ref_emb, all_ref_labels, labels, device
 
 
 def get_indices_tuple(
@@ -69,19 +78,19 @@ class DistributedLossWrapper(torch.nn.Module):
         self.loss = loss
         self.efficient = efficient
 
-    def forward(self, embeddings, labels, indices_tuple=None):
+    def forward(self, emb, labels, indices_tuple=None, ref_emb=None, ref_labels=None):
         world_size = torch.distributed.get_world_size()
         if world_size <= 1:
-            return self.loss(embeddings, labels, indices_tuple)
+            return self.loss(emb, labels, indices_tuple, ref_emb, ref_labels)
 
-        all_emb, all_labels, labels, device = gather(embeddings, labels)
+        all_emb, all_labels, all_ref_emb, all_ref_labels, labels, device = gather(emb, labels, ref_emb, ref_labels)
 
         if self.efficient:
             if indices_tuple is None:
                 indices_tuple = get_indices_tuple(labels, all_labels, device)
-            loss = self.loss(embeddings, labels, indices_tuple, all_emb, all_labels)
+            loss = self.loss(all_emb, all_labels, indices_tuple, all_ref_emb, all_ref_labels)
         else:
-            loss = self.loss(all_emb, all_labels, indices_tuple)
+            loss = self.loss(all_emb, all_labels, indices_tuple, all_ref_emb, all_ref_labels)
 
         return loss * world_size
 
@@ -94,11 +103,11 @@ class DistributedMinerWrapper(torch.nn.Module):
         self.miner = miner
         self.efficient = efficient
 
-    def forward(self, embeddings, labels):
-        all_emb, all_labels, labels, device = gather(embeddings, labels)
+    def forward(self, emb, labels, ref_emb=None, ref_labels=None):
+        all_emb, all_labels, all_ref_emb, all_ref_labels, labels, device = gather(emb, labels, ref_emb, ref_labels)
         if self.efficient:
             return get_indices_tuple(
-                labels, all_labels, device, embeddings, all_emb, self.miner
+                all_labels, all_ref_labels, device, all_emb, all_ref_emb, self.miner
             )
         else:
-            return self.miner(all_emb, all_labels)
+            return self.miner(all_emb, all_labels, all_ref_emb, all_ref_labels)

--- a/src/pytorch_metric_learning/utils/distributed.py
+++ b/src/pytorch_metric_learning/utils/distributed.py
@@ -44,7 +44,9 @@ def gather(emb, labels, ref_emb=None, ref_labels=None):
     all_labels = torch.cat([labels, dist_labels], dim=0)
 
     if ref_emb != None and ref_labels != None:
-        dist_ref_emb, dist_ref_labels = all_gather_embeddings_and_labels(ref_emb, ref_labels)
+        dist_ref_emb, dist_ref_labels = all_gather_embeddings_and_labels(
+            ref_emb, ref_labels
+        )
         all_ref_emb = torch.cat([ref_emb, dist_ref_emb], dim=0)
         all_ref_labels = torch.cat([ref_labels, dist_ref_labels], dim=0)
     else:
@@ -83,14 +85,20 @@ class DistributedLossWrapper(torch.nn.Module):
         if world_size <= 1:
             return self.loss(emb, labels, indices_tuple, ref_emb, ref_labels)
 
-        all_emb, all_labels, all_ref_emb, all_ref_labels, labels, device = gather(emb, labels, ref_emb, ref_labels)
+        all_emb, all_labels, all_ref_emb, all_ref_labels, labels, device = gather(
+            emb, labels, ref_emb, ref_labels
+        )
 
         if self.efficient:
             if indices_tuple is None:
                 indices_tuple = get_indices_tuple(labels, all_labels, device)
-            loss = self.loss(all_emb, all_labels, indices_tuple, all_ref_emb, all_ref_labels)
+            loss = self.loss(
+                all_emb, all_labels, indices_tuple, all_ref_emb, all_ref_labels
+            )
         else:
-            loss = self.loss(all_emb, all_labels, indices_tuple, all_ref_emb, all_ref_labels)
+            loss = self.loss(
+                all_emb, all_labels, indices_tuple, all_ref_emb, all_ref_labels
+            )
 
         return loss * world_size
 
@@ -104,7 +112,9 @@ class DistributedMinerWrapper(torch.nn.Module):
         self.efficient = efficient
 
     def forward(self, emb, labels, ref_emb=None, ref_labels=None):
-        all_emb, all_labels, all_ref_emb, all_ref_labels, labels, device = gather(emb, labels, ref_emb, ref_labels)
+        all_emb, all_labels, all_ref_emb, all_ref_labels, labels, device = gather(
+            emb, labels, ref_emb, ref_labels
+        )
         if self.efficient:
             return get_indices_tuple(
                 all_labels, all_ref_labels, device, all_emb, all_ref_emb, self.miner


### PR DESCRIPTION
Add compatibility of distributedwrapper for two stream input, so wrapped miner and loss can also use forward as `self.miner(query_embed, labels, doc_embed, labels.clone())` and `self.loss(query_embed, labels, doc_embed, labels.clone())`