### PR TITLE
fix bug when using CrossBatchMemory+BatchEasyHardMiner+TripletMarginLoss

### DIFF
--- a/src/pytorch_metric_learning/losses/cross_batch_memory.py
+++ b/src/pytorch_metric_learning/losses/cross_batch_memory.py
@@ -17,7 +17,7 @@ class CrossBatchMemory(ModuleWithRecords):
             list_of_names=["embedding_size", "memory_size", "queue_idx"], is_stat=False
         )
 
-    def forward(self, embeddings, labels, indices_tuple=None, enqueue_idx=None):
+    def forward(self, embeddings, labels, indices_tuple=None, enqueue_idx=None,do_remove_self_comparisons=True):
         if enqueue_idx is not None:
             assert len(enqueue_idx) <= len(self.embedding_memory)
             assert len(enqueue_idx) < len(embeddings)
@@ -44,7 +44,6 @@ class CrossBatchMemory(ModuleWithRecords):
         else:
             emb_for_queue = embeddings
             labels_for_queue = labels
-            do_remove_self_comparisons = True
 
         batch_size = len(embeddings)
         queue_batch_size = len(emb_for_queue)


### PR DESCRIPTION
when using triplet_margin_loss as loss func and using BatchEasyHardMiner as CrossBatchMemory's miner func, if pos_strategy or neg_strategy of BatchEasyHardMiner is setting to 'easy', then do_remove_self_comparisons is setting to "True" as defalut. Consequently，the ap or an pair whill be all removed, and there is no triplet to calculate tripletloss. So, I think it's one of solution to add do_remove_self_comparisons as a param of forward func of CrossBatchMemory.