### PR TITLE
Modified arcface loss to keep cost function monotonically decreasing

### DIFF
--- a/src/pytorch_metric_learning/losses/arcface_loss.py
+++ b/src/pytorch_metric_learning/losses/arcface_loss.py
@@ -21,7 +21,19 @@ class ArcFaceLoss(LargeMarginSoftmaxLoss):
 
     def modify_cosine_of_target_classes(self, cosine_of_target_classes):
         angles = self.get_angles(cosine_of_target_classes)
-        return torch.cos(angles + self.margin)
+
+        # Compute cos of (theta + margin) and cos of theta
+        cos_theta_plus_margin = torch.cos(angles + self.margin)
+        cos_theta = torch.cos(angles)
+
+        # Keep the cost function monotonically decreasing
+        unscaled_logits = torch.where(
+                                      angles <= np.deg2rad(180) - self.margin, 
+                                      cos_theta_plus_margin,
+                                      cos_theta - self.margin * np.sin(self.margin)
+                                      )
+
+        return unscaled_logits
 
     def scale_logits(self, logits, *_):
         return logits * self.scale

--- a/tests/losses/test_arcface_loss.py
+++ b/tests/losses/test_arcface_loss.py
@@ -36,9 +36,14 @@ class TestArcFaceLoss(unittest.TestCase):
 
             for i, c in enumerate(labels):
                 acos = torch.acos(torch.clamp(logits[i, c], -1, 1))
-                logits[i, c] = torch.cos(
-                    acos + torch.tensor(np.radians(margin), dtype=dtype).to(TEST_DEVICE)
-                )
+                if acos <= (np.pi - np.radians(margin)):
+                    logits[i, c] = torch.cos(
+                        acos + torch.tensor(np.radians(margin), dtype=dtype).to(TEST_DEVICE)
+                    )
+                else:
+                    mg = np.radians(margin)
+                    logits[i, c] -= torch.tensor(mg * np.sin(mg), dtype=dtype).to(TEST_DEVICE)
+
 
             correct_loss = F.cross_entropy(logits * scale, labels.to(TEST_DEVICE))
 


### PR DESCRIPTION
As mentioned in section 2.8 of the [old arcface paper](https://arxiv.org/pdf/1801.07698v1.pdf) under target logit analysis, we can see that whenever the angle between feature vector and target center is too large, the cost function behaviour can change and it wouldn't be monotonically decreasing.

Specifically, when the angle between the feature vector and target center is more obtuse than (180 - margin), the cos function can start to increase. 

For instance, consider that my margin is 30 degrees.  

If the normed feature vector makes an angle of 130 degrees with the target center, then the `logit = cos(130 + 30) = cos(160) = -0.93`. 

Now consider the normed feature vector makes an angle of 170 degrees with the target center, then the `logit = cos(170 + 30) = cos(200) = -0.93`. 

This doesn't help in our training as we want to penalize highly obtuse angle even more. Hence we make the following change in our loss function as mentioned [here](https://github.com/deepinsight/insightface/blob/master/recognition/arcface_torch/losses.py#L48) to keep this function monotonically decreasing.

Thanks,
Vinayak.
