### PR TITLE
Simplify reducers & mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 site/
 venv/
 .ipynb_checkpoints
+**/.vscode
+**/temp*_for_pytorch_metric_learning_test
 examples/notebooks/dataset
 examples/notebooks/CIFAR10_Dataset
 examples/notebooks/CIFAR100_Dataset

--- a/docs/losses.md
+++ b/docs/losses.md
@@ -111,7 +111,7 @@ losses.ArcFaceLoss(num_classes, embedding_size, margin=28.6, scale=64, **kwargs)
 
 **Other info**: 
 
-* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```weight_regularizer```, ```weight_reg_weight```, and ```weight_init_func``` as optional arguments.
+* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```regularizer```, ```reg_weight```, and ```weight_init_func``` as optional arguments.
 * This loss **requires an optimizer**. You need to create an optimizer and pass this loss's parameters to that optimizer. For example:
 ```python
 loss_func = losses.ArcFaceLoss(...).to(torch.device('cuda'))
@@ -141,8 +141,8 @@ All loss functions extend this class and therefore inherit its ```__init__``` pa
 losses.BaseMetricLossFunction(collect_stats = False, 
 							reducer = None, 
 							distance = None, 
-							embedding_regularizer = None,
-							embedding_reg_weight = 1)
+							regularizer = None,
+							reg_weight = 1)
 ```
 
 **Parameters**:
@@ -150,8 +150,8 @@ losses.BaseMetricLossFunction(collect_stats = False,
 * **collect_stats**: If True, will collect various statistics that may be useful to analyze during experiments. If False, these computations will be skipped. Want to make ```True``` the default? Set the global [COLLECT_STATS](common_functions.md#collect_stats) flag.
 * **reducer**: A [reducer](reducers.md) object. If None, then the default reducer will be used.
 * **distance**: A [distance](distances.md) object. If None, then the default distance will be used.
-* **embedding_regularizer**: A [regularizer](regularizers.md) object that will be applied to embeddings. If None, then no embedding regularization will be used.
-* **embedding_reg_weight**: If an embedding regularizer is used, then its loss will be multiplied by this amount before being added to the total loss.
+* **regularizer**: A [regularizer](regularizers.md) object that will be applied to embeddings. If None, then no embedding regularization will be used.
+* **reg_weight**: If an embedding regularizer is used, then its loss will be multiplied by this amount before being added to the total loss.
 
 **Default distance**: 
 
@@ -273,7 +273,7 @@ losses.CosFaceLoss(num_classes, embedding_size, margin=0.35, scale=64, **kwargs)
 
 **Other info**: 
 
-* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```weight_regularizer```, ```weight_reg_weight```, and ```weight_init_func``` as optional arguments.
+* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```regularizer```, ```reg_weight```, and ```weight_init_func``` as optional arguments.
 * This loss **requires an optimizer**. You need to create an optimizer and pass this loss's parameters to that optimizer. For example:
 ```python
 loss_func = losses.CosFaceLoss(...).to(torch.device('cuda'))
@@ -491,7 +491,7 @@ where
 
 **Other info**: 
 
-* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```weight_regularizer```, ```weight_reg_weight```, and ```weight_init_func``` as optional arguments.
+* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```regularizer```, ```reg_weight```, and ```weight_init_func``` as optional arguments.
 * This loss **requires an optimizer**. You need to create an optimizer and pass this loss's parameters to that optimizer. For example:
 ```python
 loss_func = losses.LargeMarginSoftmaxLoss(...).to(torch.device('cuda'))
@@ -737,7 +737,7 @@ losses.NormalizedSoftmaxLoss(num_classes, embedding_size, temperature=0.05, **kw
 
 **Other info**
 
-* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```weight_regularizer```, ```weight_reg_weight```, and ```weight_init_func``` as optional arguments.
+* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```regularizer```, ```reg_weight```, and ```weight_init_func``` as optional arguments.
 * This loss **requires an optimizer**. You need to create an optimizer and pass this loss's parameters to that optimizer. For example:
 ```python
 loss_func = losses.NormalizedSoftmaxLoss(...).to(torch.device('cuda'))
@@ -870,7 +870,7 @@ losses.ProxyAnchorLoss(num_classes, embedding_size, margin = 0.1, alpha = 32, **
 
 **Other info**
 
-* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```weight_regularizer```, ```weight_reg_weight```, and ```weight_init_func``` as optional arguments.
+* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```regularizer```, ```reg_weight```, and ```weight_init_func``` as optional arguments.
 * This loss **requires an optimizer**. You need to create an optimizer and pass this loss's parameters to that optimizer. For example:
 ```python
 loss_func = losses.ProxyAnchorLoss(...).to(torch.device('cuda'))
@@ -907,7 +907,7 @@ losses.ProxyNCALoss(num_classes, embedding_size, softmax_scale=1, **kwargs)
 
 **Other info**
 
-* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```weight_regularizer```, ```weight_reg_weight```, and ```weight_init_func``` as optional arguments.
+* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```regularizer```, ```reg_weight```, and ```weight_init_func``` as optional arguments.
 * This loss **requires an optimizer**. You need to create an optimizer and pass this loss's parameters to that optimizer. For example:
 ```python
 loss_func = losses.ProxyNCALoss(...).to(torch.device('cuda'))
@@ -1027,7 +1027,7 @@ where
 
 **Other info**
 
-* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```weight_regularizer```, ```weight_reg_weight```, and ```weight_init_func``` as optional arguments.
+* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```regularizer```, ```reg_weight```, and ```weight_init_func``` as optional arguments.
 * This loss **requires an optimizer**. You need to create an optimizer and pass this loss's parameters to that optimizer. For example:
 ```python
 loss_func = losses.SoftTripleLoss(...).to(torch.device('cuda'))
@@ -1068,7 +1068,7 @@ See [LargeMarginSoftmaxLoss](losses.md#largemarginsoftmaxloss)
 
 **Other info**
 
-* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```weight_regularizer```, ```weight_reg_weight```, and ```weight_init_func``` as optional arguments.
+* This also extends [WeightRegularizerMixin](losses.md#weightregularizermixin), so it accepts ```regularizer```, ```reg_weight```, and ```weight_init_func``` as optional arguments.
 * This loss **requires an optimizer**. You need to create an optimizer and pass this loss's parameters to that optimizer. For example:
 ```python
 loss_func = losses.SphereFaceLoss(...).to(torch.device('cuda'))
@@ -1230,14 +1230,14 @@ complete_loss = losses.MultipleLosses([main_loss, var_loss], weights=[1, 0.5])
 ## WeightRegularizerMixin
 Losses can extend this class in addition to BaseMetricLossFunction. You should extend this class if your loss function contains a learnable weight matrix.
 ```python
-losses.WeightRegularizerMixin(weight_init_func=None, weight_regularizer=None, weight_reg_weight=1, **kwargs)
+losses.WeightRegularizerMixin(weight_init_func=None, regularizer=None, reg_weight=1, **kwargs)
 ```
 
 **Parameters**:
 
 * **weight_init_func**: An [TorchInitWrapper](common_functions.md#torchinitwrapper) object, which will be used to initialize the weights of the loss function.
-* **weight_regularizer**: The [regularizer](regularizers.md) to apply to the loss's learned weights.
-* **weight_reg_weight**: The amount the regularization loss will be multiplied by.
+* **regularizer**: The [regularizer](regularizers.md) to apply to the loss's learned weights.
+* **reg_weight**: The amount the regularization loss will be multiplied by.
 
 Extended by:
 

--- a/src/pytorch_metric_learning/losses/margin_loss.py
+++ b/src/pytorch_metric_learning/losses/margin_loss.py
@@ -36,7 +36,11 @@ class MarginLoss(BaseMetricLossFunction):
         if len(anchor_idx) == 0:
             return self.zero_losses()
 
-        beta = self.beta if len(self.beta) == 1 else self.beta[labels[anchor_idx].to("cpu")]    # When labels are on gpu gives error
+        beta = (
+            self.beta
+            if len(self.beta) == 1
+            else self.beta[labels[anchor_idx].to("cpu")]
+        )  # When labels are on gpu gives error
         beta = c_f.to_device(beta, device=embeddings.device, dtype=embeddings.dtype)
 
         mat = self.distance(embeddings, ref_emb)

--- a/src/pytorch_metric_learning/losses/margin_loss.py
+++ b/src/pytorch_metric_learning/losses/margin_loss.py
@@ -36,7 +36,7 @@ class MarginLoss(BaseMetricLossFunction):
         if len(anchor_idx) == 0:
             return self.zero_losses()
 
-        beta = self.beta if len(self.beta) == 1 else self.beta[labels[anchor_idx]]
+        beta = self.beta if len(self.beta) == 1 else self.beta[labels[anchor_idx].to("cpu")]    # When labels are on gpu gives error
         beta = c_f.to_device(beta, device=embeddings.device, dtype=embeddings.dtype)
 
         mat = self.distance(embeddings, ref_emb)

--- a/src/pytorch_metric_learning/losses/vicreg_loss.py
+++ b/src/pytorch_metric_learning/losses/vicreg_loss.py
@@ -11,7 +11,7 @@ class VICRegLoss(BaseMetricLossFunction):
     ):
         if "distance" in kwargs:
             raise ValueError("VICRegLoss cannot use a distance function")
-        if "embedding_regularizer" in kwargs:
+        if "regularizer" in kwargs:
             raise ValueError("VICRegLoss cannot use a regularizer")
         super().__init__(**kwargs)
         """

--- a/src/pytorch_metric_learning/reducers/avg_non_zero_reducer.py
+++ b/src/pytorch_metric_learning/reducers/avg_non_zero_reducer.py
@@ -3,5 +3,6 @@ from .threshold_reducer import ThresholdReducer
 
 class AvgNonZeroReducer(ThresholdReducer):
     """Equivalent to ThresholdReducer with `low=0`"""
+
     def __init__(self, **kwargs):
         super().__init__(low=0, **kwargs)

--- a/src/pytorch_metric_learning/reducers/avg_non_zero_reducer.py
+++ b/src/pytorch_metric_learning/reducers/avg_non_zero_reducer.py
@@ -2,5 +2,6 @@ from .threshold_reducer import ThresholdReducer
 
 
 class AvgNonZeroReducer(ThresholdReducer):
+    """Equivalent to ThresholdReducer with `low=0`"""
     def __init__(self, **kwargs):
         super().__init__(low=0, **kwargs)

--- a/src/pytorch_metric_learning/reducers/base_reducer.py
+++ b/src/pytorch_metric_learning/reducers/base_reducer.py
@@ -15,7 +15,7 @@ class BaseReducer(ModuleWithRecords):
         loss_name = list(loss_dict.keys())[0]
         loss_info = loss_dict[loss_name]
         losses, loss_indices, reduction_type, kwargs = self.unpack_loss_info(loss_info)
-        loss_val = self.reduce_the_loss(
+        loss_val = self.reduce_loss(        # Similar to compute_loss
             losses, loss_indices, reduction_type, kwargs, embeddings, labels
         )
         return loss_val
@@ -28,7 +28,7 @@ class BaseReducer(ModuleWithRecords):
             {},
         )
 
-    def reduce_the_loss(
+    def reduce_loss(        # Similar to compute_loss
         self, losses, loss_indices, reduction_type, kwargs, embeddings, labels
     ):
         self.set_losses_size_stat(losses)

--- a/src/pytorch_metric_learning/reducers/base_reducer.py
+++ b/src/pytorch_metric_learning/reducers/base_reducer.py
@@ -15,7 +15,7 @@ class BaseReducer(ModuleWithRecords):
         loss_name = list(loss_dict.keys())[0]
         loss_info = loss_dict[loss_name]
         losses, loss_indices, reduction_type, kwargs = self.unpack_loss_info(loss_info)
-        loss_val = self.reduce_loss(        # Similar to compute_loss
+        loss_val = self.reduce_loss(  # Similar to compute_loss
             losses, loss_indices, reduction_type, kwargs, embeddings, labels
         )
         return loss_val
@@ -28,7 +28,7 @@ class BaseReducer(ModuleWithRecords):
             {},
         )
 
-    def reduce_loss(        # Similar to compute_loss
+    def reduce_loss(  # Similar to compute_loss
         self, losses, loss_indices, reduction_type, kwargs, embeddings, labels
     ):
         self.set_losses_size_stat(losses)

--- a/src/pytorch_metric_learning/reducers/class_weighted_reducer.py
+++ b/src/pytorch_metric_learning/reducers/class_weighted_reducer.py
@@ -4,8 +4,10 @@ from .threshold_reducer import ThresholdReducer
 
 class ClassWeightedReducer(ThresholdReducer):
     """It weights the losses with user-specified weights and then takes the average.
-    
-    Subclass of ThresholdReducer, therefore it is possible to specify `low` and `high` hyperparameters."""
+
+    Subclass of ThresholdReducer, therefore it is possible to specify `low` and `high` hyperparameters.
+    """
+
     def __init__(self, weights, **kwargs):
         super().__init__(**kwargs)
         self.weights = weights

--- a/src/pytorch_metric_learning/reducers/divisor_reducer.py
+++ b/src/pytorch_metric_learning/reducers/divisor_reducer.py
@@ -7,28 +7,23 @@ from .base_reducer import BaseReducer
 class DivisorReducer(BaseReducer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.divisor = 1
         self.add_to_recordable_attributes(name="divisor", is_stat=True)
 
     def unpack_loss_info(self, loss_info):
-        losses, loss_indices, reduction_type, kwargs = super().unpack_loss_info(
-            loss_info
-        )
-        if reduction_type != "already_reduced":
-            kwargs = {"divisor": loss_info["divisor"]}
-            self.divisor = kwargs["divisor"]
-        return losses, loss_indices, reduction_type, kwargs
-
-    def sum_and_divide(self, losses, embeddings, divisor):
-        if divisor != 0:
-            output = torch.sum(losses) / divisor
-            if torch.isnan(output) and losses.dtype == torch.float16:
-                output = torch.sum(c_f.to_dtype(losses, dtype=torch.float32)) / divisor
-                output = c_f.to_dtype(output, dtype=torch.float16)
+        if loss_info["reduction_type"] != "already_reduced":
+            self.divisor = loss_info["divisor"]
+        return super().unpack_loss_info(loss_info)
+        
+    def sum_and_divide(self, losses, embeddings):
+        if self.divisor != 0:
+            output = torch.sum(losses.float()) / self.divisor
+            output = c_f.to_dtype(output, tensor=losses)
             return output
         return self.zero_loss(embeddings)
 
-    def element_reduction(self, losses, loss_indices, embeddings, labels, divisor=1):
-        return self.sum_and_divide(losses, embeddings, divisor)
+    def element_reduction(self, losses, loss_indices, embeddings, labels):
+        return self.sum_and_divide(losses, embeddings)
 
     def pos_pair_reduction(self, *args, **kwargs):
         return self.element_reduction(*args, **kwargs)

--- a/src/pytorch_metric_learning/reducers/divisor_reducer.py
+++ b/src/pytorch_metric_learning/reducers/divisor_reducer.py
@@ -14,7 +14,7 @@ class DivisorReducer(BaseReducer):
         if loss_info["reduction_type"] != "already_reduced":
             self.divisor = loss_info["divisor"]
         return super().unpack_loss_info(loss_info)
-        
+
     def sum_and_divide(self, losses, embeddings):
         if self.divisor != 0:
             output = torch.sum(losses.float()) / self.divisor

--- a/src/pytorch_metric_learning/reducers/do_nothing_reducer.py
+++ b/src/pytorch_metric_learning/reducers/do_nothing_reducer.py
@@ -2,5 +2,5 @@ from .base_reducer import BaseReducer
 
 
 class DoNothingReducer(BaseReducer):
-    def forward(self, loss_dict, embeddings, labels):
+    def forward(self, loss_dict, *_):
         return loss_dict

--- a/src/pytorch_metric_learning/reducers/mean_reducer.py
+++ b/src/pytorch_metric_learning/reducers/mean_reducer.py
@@ -1,17 +1,13 @@
-import torch
+from .threshold_reducer import ThresholdReducer
+import numpy as np
 
-from .base_reducer import BaseReducer
 
+class MeanReducer(ThresholdReducer):
+    """Equivalent to ThresholdReducer with default parameters.
+    
+    Any element is accepted"""
+    def __init__(self, **kwargs):
+        kwargs["low"] = -np.inf
+        kwargs["high"] = np.inf
+        super().__init__(**kwargs)
 
-class MeanReducer(BaseReducer):
-    def element_reduction(self, losses, *_):
-        return torch.mean(losses)
-
-    def pos_pair_reduction(self, losses, *args):
-        return self.element_reduction(losses, *args)
-
-    def neg_pair_reduction(self, losses, *args):
-        return self.element_reduction(losses, *args)
-
-    def triplet_reduction(self, losses, *args):
-        return self.element_reduction(losses, *args)

--- a/src/pytorch_metric_learning/reducers/mean_reducer.py
+++ b/src/pytorch_metric_learning/reducers/mean_reducer.py
@@ -1,13 +1,14 @@
-from .threshold_reducer import ThresholdReducer
 import numpy as np
+
+from .threshold_reducer import ThresholdReducer
 
 
 class MeanReducer(ThresholdReducer):
     """Equivalent to ThresholdReducer with default parameters.
-    
+
     Any element is accepted"""
+
     def __init__(self, **kwargs):
         kwargs["low"] = -np.inf
         kwargs["high"] = np.inf
         super().__init__(**kwargs)
-

--- a/src/pytorch_metric_learning/reducers/multiple_reducers.py
+++ b/src/pytorch_metric_learning/reducers/multiple_reducers.py
@@ -2,30 +2,32 @@ import torch
 
 from .base_reducer import BaseReducer
 from .mean_reducer import MeanReducer
+from collections import defaultdict
+
+class DefaultModuleDict(torch.nn.ModuleDict):
+    def __init__(self, module_factory, modules):
+        torch.nn.ModuleDict.__init__(self, modules)
+        self._modules = defaultdict(module_factory, self._modules)
 
 
 class MultipleReducers(BaseReducer):
-    def __init__(self, reducers, default_reducer=None, **kwargs):
+    def __init__(self, reducers, default_reducer: BaseReducer = None, **kwargs):
         super().__init__(**kwargs)
-        self.reducers = torch.nn.ModuleDict(reducers)
-        self.default_reducer = (
-            MeanReducer() if default_reducer is None else default_reducer
-        )
+        reducer_type = MeanReducer if default_reducer is None else type(default_reducer)
+        self.reducers = DefaultModuleDict(module_factory=lambda : reducer_type(), 
+                                          modules=reducers)
 
     def forward(self, loss_dict, embeddings, labels):
         self.reset_stats()
         sub_losses = torch.zeros(
             len(loss_dict), dtype=embeddings.dtype, device=embeddings.device
         )
-        loss_count = 0
-        for loss_name, loss_info in loss_dict.items():
+
+        for loss_count, (loss_name, loss_info) in enumerate(loss_dict.items()):
             input_dict = {loss_name: loss_info}
-            if loss_name in self.reducers:
-                loss_val = self.reducers[loss_name](input_dict, embeddings, labels)
-            else:
-                loss_val = self.default_reducer(input_dict, embeddings, labels)
+            loss_val = self.reducers[loss_name](input_dict, embeddings, labels)
             sub_losses[loss_count] = loss_val
-            loss_count += 1
+
         return self.sub_loss_reduction(sub_losses, embeddings, labels)
 
     def sub_loss_reduction(self, sub_losses, embeddings=None, labels=None):

--- a/src/pytorch_metric_learning/reducers/multiple_reducers.py
+++ b/src/pytorch_metric_learning/reducers/multiple_reducers.py
@@ -1,8 +1,10 @@
+from collections import defaultdict
+
 import torch
 
 from .base_reducer import BaseReducer
 from .mean_reducer import MeanReducer
-from collections import defaultdict
+
 
 class DefaultModuleDict(torch.nn.ModuleDict):
     def __init__(self, module_factory, modules):
@@ -14,8 +16,9 @@ class MultipleReducers(BaseReducer):
     def __init__(self, reducers, default_reducer: BaseReducer = None, **kwargs):
         super().__init__(**kwargs)
         reducer_type = MeanReducer if default_reducer is None else type(default_reducer)
-        self.reducers = DefaultModuleDict(module_factory=lambda : reducer_type(), 
-                                          modules=reducers)
+        self.reducers = DefaultModuleDict(
+            module_factory=lambda: reducer_type(), modules=reducers
+        )
 
     def forward(self, loss_dict, embeddings, labels):
         self.reset_stats()

--- a/src/pytorch_metric_learning/reducers/per_anchor_reducer.py
+++ b/src/pytorch_metric_learning/reducers/per_anchor_reducer.py
@@ -35,15 +35,21 @@ class PerAnchorReducer(BaseReducer):
         # Prepare tensors for results
         anchors = c_f.to_device(anchors, tensor=losses)
         others = c_f.to_device(others, tensor=losses)
-        output = c_f.to_device(torch.zeros(batch_size, batch_size), tensor=losses, dtype=losses.dtype)
-        num_per_row = c_f.to_device(torch.zeros(batch_size), tensor=losses, dtype=torch.long)     # Remember to fuse in an unique call to to_device when to_device will accept list inputs
+        output = c_f.to_device(
+            torch.zeros(batch_size, batch_size), tensor=losses, dtype=losses.dtype
+        )
+        num_per_row = c_f.to_device(
+            torch.zeros(batch_size), tensor=losses, dtype=torch.long
+        )  # Remember to fuse in an unique call to to_device when to_device will accept list inputs
 
         # Insert loss values in corresponence of anchor-embedding
         output[anchors, others] = losses
 
         # Calculate the count of 'others' for each unique anchor
         # Equivalent to:    'num_per_row[anchors[i]] += 1'     for every i
-        num_per_row = num_per_row.scatter_add_(0, anchors, torch.ones_like(anchors, device=anchors.device))
+        num_per_row = num_per_row.scatter_add_(
+            0, anchors, torch.ones_like(anchors, device=anchors.device)
+        )
 
         # Aggregate results
         output = self.aggregation_func(output, num_per_row)
@@ -63,5 +69,5 @@ class PerAnchorReducer(BaseReducer):
     def neg_pair_reduction(self, *args, **kwargs):
         return self.tuple_reduction_helper(*args, **kwargs)
 
-    def triplet_reduction(self, *_):        # Explicitly indicate hyperparameters are ignored
+    def triplet_reduction(self, *_):  # Explicitly indicate hyperparameters are ignored
         raise NotImplementedError("Triplet reduction not supported")

--- a/src/pytorch_metric_learning/reducers/sum_reducer.py
+++ b/src/pytorch_metric_learning/reducers/sum_reducer.py
@@ -1,8 +1,15 @@
 import torch
 
-from pytorch_metric_learning.reducers import MeanReducer
+from .threshold_reducer import ThresholdReducer
 
 
-class SumReducer(MeanReducer):
+class SumReducer(ThresholdReducer):
+    """It reduces the losses by summing up all the values.
+    
+    Subclass of ThresholdReducer, therefore it is possible to specify `low` and `high` hyperparameters."""
+    def __init__(self, **kwargs):
+        kwargs["collect_stats"] = True
+        super().__init__(**kwargs)
+
     def element_reduction(self, losses, *_):
-        return torch.sum(losses)
+        return super().element_reduction(losses, *_) * self.num_past_filter

--- a/src/pytorch_metric_learning/reducers/sum_reducer.py
+++ b/src/pytorch_metric_learning/reducers/sum_reducer.py
@@ -1,12 +1,12 @@
-import torch
-
 from .threshold_reducer import ThresholdReducer
 
 
 class SumReducer(ThresholdReducer):
     """It reduces the losses by summing up all the values.
-    
-    Subclass of ThresholdReducer, therefore it is possible to specify `low` and `high` hyperparameters."""
+
+    Subclass of ThresholdReducer, therefore it is possible to specify `low` and `high` hyperparameters.
+    """
+
     def __init__(self, **kwargs):
         kwargs["collect_stats"] = True
         super().__init__(**kwargs)

--- a/src/pytorch_metric_learning/reducers/threshold_reducer.py
+++ b/src/pytorch_metric_learning/reducers/threshold_reducer.py
@@ -1,16 +1,13 @@
 import torch
-
+import numpy as np
 from .base_reducer import BaseReducer
 
 
 class ThresholdReducer(BaseReducer):
-    def __init__(self, low=None, high=None, **kwargs):
+    def __init__(self, low=-np.inf, high=np.inf, **kwargs):
         super().__init__(**kwargs)
-        assert (low is not None) or (
-            high is not None
-        ), "At least one of low or high must be specified"
-        self.low = low
-        self.high = high
+        self.low = low if low is not None else -np.inf       # Since there is no None default value it could be better to exclude testing for low=None in test_treshold_reducer
+        self.high = high if high is not None else np.inf     # Since there is no None default value it could be better to exclude testing for high=None in test_treshold_reducer
         self.add_to_recordable_attributes(list_of_names=["low", "high"], is_stat=False)
         self.add_to_recordable_attributes(
             list_of_names=["num_past_filter", "num_above_low", "num_below_high"],
@@ -21,22 +18,19 @@ class ThresholdReducer(BaseReducer):
         return self.element_reduction_helper(losses, embeddings)
 
     def pos_pair_reduction(self, losses, loss_indices, embeddings, labels):
-        return self.element_reduction_helper(losses, embeddings)
+        return self.element_reduction(losses, loss_indices[0], embeddings, labels)
 
     def neg_pair_reduction(self, losses, loss_indices, embeddings, labels):
-        return self.element_reduction_helper(losses, embeddings)
+        return self.element_reduction(losses, loss_indices[0], embeddings, labels)
 
     def triplet_reduction(self, losses, loss_indices, embeddings, labels):
-        return self.element_reduction_helper(losses, embeddings)
+        return self.element_reduction(losses, loss_indices[0], embeddings, labels)
 
     def element_reduction_helper(self, losses, embeddings):
-        low_condition, high_condition = None, None
-        if self.low is not None:
-            low_condition = losses > self.low
-            losses = losses[low_condition]
-        if self.high is not None:
-            high_condition = losses < self.high
-            losses = losses[high_condition]
+        low_condition = losses > self.low
+        high_condition = losses < self.high
+        losses = losses[low_condition & high_condition]
+        
         num_past_filter = len(losses)
         if num_past_filter >= 1:
             loss = torch.mean(losses)
@@ -45,11 +39,11 @@ class ThresholdReducer(BaseReducer):
         self.set_stats(low_condition, high_condition, num_past_filter)
         return loss
 
+    @torch.no_grad()
     def set_stats(self, low_condition, high_condition, num_past_filter):
         if self.collect_stats:
             self.num_past_filter = num_past_filter
-            with torch.no_grad():
-                if self.low is not None:
-                    self.num_above_low = torch.sum(low_condition).item()
-                if self.high is not None:
-                    self.num_above_high = torch.sum(high_condition).item()
+            if np.isfinite(self.low):       # Why record this only if it was not None?
+                self.num_above_low = torch.sum(low_condition).item()
+            if np.isfinite(self.high):      # Why record this only if it was not None?
+                self.num_above_high = torch.sum(high_condition).item()

--- a/src/pytorch_metric_learning/reducers/threshold_reducer.py
+++ b/src/pytorch_metric_learning/reducers/threshold_reducer.py
@@ -1,13 +1,18 @@
-import torch
 import numpy as np
+import torch
+
 from .base_reducer import BaseReducer
 
 
 class ThresholdReducer(BaseReducer):
     def __init__(self, low=-np.inf, high=np.inf, **kwargs):
         super().__init__(**kwargs)
-        self.low = low if low is not None else -np.inf       # Since there is no None default value it could be better to exclude testing for low=None in test_treshold_reducer
-        self.high = high if high is not None else np.inf     # Since there is no None default value it could be better to exclude testing for high=None in test_treshold_reducer
+        self.low = (
+            low if low is not None else -np.inf
+        )  # Since there is no None default value it could be better to exclude testing for low=None in test_treshold_reducer
+        self.high = (
+            high if high is not None else np.inf
+        )  # Since there is no None default value it could be better to exclude testing for high=None in test_treshold_reducer
         self.add_to_recordable_attributes(list_of_names=["low", "high"], is_stat=False)
         self.add_to_recordable_attributes(
             list_of_names=["num_past_filter", "num_above_low", "num_below_high"],
@@ -30,7 +35,7 @@ class ThresholdReducer(BaseReducer):
         low_condition = losses > self.low
         high_condition = losses < self.high
         losses = losses[low_condition & high_condition]
-        
+
         num_past_filter = len(losses)
         if num_past_filter >= 1:
             loss = torch.mean(losses)
@@ -43,7 +48,7 @@ class ThresholdReducer(BaseReducer):
     def set_stats(self, low_condition, high_condition, num_past_filter):
         if self.collect_stats:
             self.num_past_filter = num_past_filter
-            if np.isfinite(self.low):       # Why record this only if it was not None?
+            if np.isfinite(self.low):  # Why record this only if it was not None?
                 self.num_above_low = torch.sum(low_condition).item()
-            if np.isfinite(self.high):      # Why record this only if it was not None?
+            if np.isfinite(self.high):  # Why record this only if it was not None?
                 self.num_above_high = torch.sum(high_condition).item()

--- a/src/pytorch_metric_learning/utils/logging_presets.py
+++ b/src/pytorch_metric_learning/utils/logging_presets.py
@@ -379,7 +379,7 @@ class HookContainer:
 
 
 class EmptyContainer:
-    def end_of_epoch_hook(self, *args):
+    def end_of_epoch_hook(self, *_, **__):       # Gives "TypeError: EmptyContainer.end_of_epoch_hook() got an unexpected keyword argument 'test_interval'"
         return None
 
     end_of_iteration_hook = None

--- a/src/pytorch_metric_learning/utils/logging_presets.py
+++ b/src/pytorch_metric_learning/utils/logging_presets.py
@@ -379,7 +379,9 @@ class HookContainer:
 
 
 class EmptyContainer:
-    def end_of_epoch_hook(self, *_, **__):       # Gives "TypeError: EmptyContainer.end_of_epoch_hook() got an unexpected keyword argument 'test_interval'"
+    def end_of_epoch_hook(
+        self, *_, **__
+    ):  # Gives "TypeError: EmptyContainer.end_of_epoch_hook() got an unexpected keyword argument 'test_interval'"
         return None
 
     end_of_iteration_hook = None

--- a/src/pytorch_metric_learning/utils/module_with_records.py
+++ b/src/pytorch_metric_learning/utils/module_with_records.py
@@ -4,7 +4,9 @@ from . import common_functions as c_f
 
 
 class ModuleWithRecords(torch.nn.Module):
-    def __init__(self, collect_stats=None):
+    def __init__(
+        self, collect_stats=None, **_
+    ):  # Hack needed to ignore other arguments passed from subclasses
         super().__init__()
         self.collect_stats = (
             c_f.COLLECT_STATS if collect_stats is None else collect_stats

--- a/tests/losses/test_npairs_loss.py
+++ b/tests/losses/test_npairs_loss.py
@@ -12,7 +12,7 @@ from ..zzz_testing_utils.testing_utils import angle_to_coord
 class TestNPairsLoss(unittest.TestCase):
     def test_npairs_loss(self):
         loss_funcA = NPairsLoss()
-        loss_funcB = NPairsLoss(embedding_regularizer=LpRegularizer(power=2))
+        loss_funcB = NPairsLoss(regularizer=LpRegularizer(power=2))
         embedding_norm = 2.3
 
         for dtype in TEST_DTYPES:
@@ -76,7 +76,7 @@ class TestNPairsLoss(unittest.TestCase):
 
     def test_backward(self):
         loss_funcA = NPairsLoss()
-        loss_funcB = NPairsLoss(embedding_regularizer=LpRegularizer())
+        loss_funcB = NPairsLoss(regularizer=LpRegularizer())
 
         for dtype in TEST_DTYPES:
             for loss_func in [loss_funcA, loss_funcB]:

--- a/tests/losses/test_soft_triple_loss.py
+++ b/tests/losses/test_soft_triple_loss.py
@@ -78,11 +78,11 @@ class TestSoftTripleLoss(unittest.TestCase):
             gamma = 1 if dtype == torch.float16 else 0.1
             for centers_per_class in range(1, 12):
                 if centers_per_class > 1:
-                    weight_regularizer = SparseCentersRegularizer(
+                    regularizer = SparseCentersRegularizer(
                         num_classes, centers_per_class
                     )
                 else:
-                    weight_regularizer = None
+                    regularizer = None
                 loss_func = SoftTripleLoss(
                     num_classes,
                     embedding_size,
@@ -90,8 +90,8 @@ class TestSoftTripleLoss(unittest.TestCase):
                     la=la,
                     gamma=gamma,
                     margin=margin,
-                    weight_regularizer=weight_regularizer,
-                    weight_reg_weight=reg_weight,
+                    regularizer=regularizer,
+                    reg_weight=reg_weight,
                 ).to(TEST_DEVICE)
                 original_loss_func = OriginalImplementationSoftTriple(
                     la,

--- a/tests/reducers/test_class_weighted_reducer.py
+++ b/tests/reducers/test_class_weighted_reducer.py
@@ -11,8 +11,15 @@ class TestClassWeightedReducer(unittest.TestCase):
     def test_class_weighted_reducer_with_threshold(self):
         torch.manual_seed(99115)
         class_weights = torch.tensor([1, 0.9, 1, 0.1, 0, 0, 0, 0, 0, 0])
-        for low_threshold, high_threshold in [(None, None), (0.1, None), (None, 0.2), (0.1, 0.2)]:
-            reducer = ClassWeightedReducer(class_weights, low=low_threshold, high=high_threshold)
+        for low_threshold, high_threshold in [
+            (None, None),
+            (0.1, None),
+            (None, 0.2),
+            (0.1, 0.2),
+        ]:
+            reducer = ClassWeightedReducer(
+                class_weights, low=low_threshold, high=high_threshold
+            )
             batch_size = 100
             embedding_size = 64
             for dtype in TEST_DTYPES:
@@ -59,13 +66,17 @@ class TestClassWeightedReducer(unittest.TestCase):
                                 class_label = labels[batch_idx]
                                 correct_output += (
                                     L[i]
-                                    * class_weights.type(dtype).to(TEST_DEVICE)[class_label]
+                                    * class_weights.type(dtype).to(TEST_DEVICE)[
+                                        class_label
+                                    ]
                                 )
                             correct_output /= len(L)
                         else:
                             correct_output = 0
                         rtol = 1e-2 if dtype == torch.float16 else 1e-5
-                        self.assertTrue(torch.isclose(output, correct_output, rtol=rtol))
+                        self.assertTrue(
+                            torch.isclose(output, correct_output, rtol=rtol)
+                        )
 
                         if WITH_COLLECT_STATS:
                             self.assertTrue(reducer.num_past_filter == len(L))

--- a/tests/reducers/test_divisor_reducer.py
+++ b/tests/reducers/test_divisor_reducer.py
@@ -53,7 +53,8 @@ class TestDivisorReducer(unittest.TestCase):
                         correct_output = torch.sum(L) * 0
                     else:
                         correct_output = torch.sum(L) / (32 + 15)
-                    self.assertTrue(output == correct_output)
+                    rtol = 1e-2 if dtype == torch.float16 else 1e-5
+                    self.assertTrue(torch.isclose(output, correct_output, rtol=rtol))
 
             loss_dict = {
                 "loss": {

--- a/tests/reducers/test_multiple_reducers.py
+++ b/tests/reducers/test_multiple_reducers.py
@@ -56,4 +56,5 @@ class TestMultipleReducers(unittest.TestCase):
                 correct_output = (torch.mean(lossesA[lossesA > 0])) + (
                     torch.sum(lossesB) / (32 + 15)
                 )
-                self.assertTrue(output == correct_output)
+                rtol = 1e-2 if dtype == torch.float16 else 1e-5
+                self.assertTrue(torch.isclose(output, correct_output, rtol=rtol))

--- a/tests/reducers/test_sum_reducer.py
+++ b/tests/reducers/test_sum_reducer.py
@@ -2,17 +2,16 @@ import unittest
 
 import torch
 
-from pytorch_metric_learning.reducers import ClassWeightedReducer
+from pytorch_metric_learning.reducers import SumReducer
 
 from .. import TEST_DEVICE, TEST_DTYPES, WITH_COLLECT_STATS
 
 
-class TestClassWeightedReducer(unittest.TestCase):
-    def test_class_weighted_reducer_with_threshold(self):
+class TestSumReducer(unittest.TestCase):
+    def test_sum_reducer_with_thresholds(self):
         torch.manual_seed(99115)
-        class_weights = torch.tensor([1, 0.9, 1, 0.1, 0, 0, 0, 0, 0, 0])
         for low_threshold, high_threshold in [(None, None), (0.1, None), (None, 0.2), (0.1, 0.2)]:
-            reducer = ClassWeightedReducer(class_weights, low=low_threshold, high=high_threshold)
+            reducer = SumReducer(low=low_threshold, high=high_threshold)
             batch_size = 100
             embedding_size = 64
             for dtype in TEST_DTYPES:
@@ -50,20 +49,9 @@ class TestClassWeightedReducer(unittest.TestCase):
                         if high_threshold is not None:
                             L = L[L < high_threshold]
                         if len(L) > 0:
-                            correct_output = 0
-                            for i in range(len(L)):
-                                if reduction_type == "element":
-                                    batch_idx = indices[i]
-                                else:
-                                    batch_idx = indices[0][i]
-                                class_label = labels[batch_idx]
-                                correct_output += (
-                                    L[i]
-                                    * class_weights.type(dtype).to(TEST_DEVICE)[class_label]
-                                )
-                            correct_output /= len(L)
+                            correct_output = torch.sum(L, dtype=dtype)
                         else:
-                            correct_output = 0
+                            correct_output = torch.zeros(1, dtype=dtype, device=TEST_DEVICE)
                         rtol = 1e-2 if dtype == torch.float16 else 1e-5
                         self.assertTrue(torch.isclose(output, correct_output, rtol=rtol))
 

--- a/tests/reducers/test_sum_reducer.py
+++ b/tests/reducers/test_sum_reducer.py
@@ -10,7 +10,12 @@ from .. import TEST_DEVICE, TEST_DTYPES, WITH_COLLECT_STATS
 class TestSumReducer(unittest.TestCase):
     def test_sum_reducer_with_thresholds(self):
         torch.manual_seed(99115)
-        for low_threshold, high_threshold in [(None, None), (0.1, None), (None, 0.2), (0.1, 0.2)]:
+        for low_threshold, high_threshold in [
+            (None, None),
+            (0.1, None),
+            (None, 0.2),
+            (0.1, 0.2),
+        ]:
             reducer = SumReducer(low=low_threshold, high=high_threshold)
             batch_size = 100
             embedding_size = 64
@@ -51,9 +56,13 @@ class TestSumReducer(unittest.TestCase):
                         if len(L) > 0:
                             correct_output = torch.sum(L, dtype=dtype)
                         else:
-                            correct_output = torch.zeros(1, dtype=dtype, device=TEST_DEVICE)
+                            correct_output = torch.zeros(
+                                1, dtype=dtype, device=TEST_DEVICE
+                            )
                         rtol = 1e-2 if dtype == torch.float16 else 1e-5
-                        self.assertTrue(torch.isclose(output, correct_output, rtol=rtol))
+                        self.assertTrue(
+                            torch.isclose(output, correct_output, rtol=rtol)
+                        )
 
                         if WITH_COLLECT_STATS:
                             self.assertTrue(reducer.num_past_filter == len(L))

--- a/tests/regularizers/test_center_invariant_regularizer.py
+++ b/tests/regularizers/test_center_invariant_regularizer.py
@@ -19,8 +19,8 @@ class TestCenterInvariantRegularizer(unittest.TestCase):
                 temperature=temperature,
                 num_classes=num_classes,
                 embedding_size=embedding_size,
-                weight_regularizer=CenterInvariantRegularizer(),
-                weight_reg_weight=reg_weight,
+                regularizer=CenterInvariantRegularizer(),
+                reg_weight=reg_weight,
             ).to(TEST_DEVICE)
 
             embeddings = torch.nn.functional.normalize(

--- a/tests/regularizers/test_regular_face_regularizer.py
+++ b/tests/regularizers/test_regular_face_regularizer.py
@@ -20,8 +20,8 @@ class TestRegularFaceRegularizer(unittest.TestCase):
                 temperature=temperature,
                 num_classes=num_classes,
                 embedding_size=embedding_size,
-                weight_regularizer=RegularFaceRegularizer(),
-                weight_reg_weight=reg_weight,
+                regularizer=RegularFaceRegularizer(),
+                reg_weight=reg_weight,
             ).to(TEST_DEVICE)
 
             embeddings = torch.nn.functional.normalize(


### PR DESCRIPTION
I have put my thought in refactoring reducers and mixins. In some cases i have updated the tests relative to new functionality that could be added easily to the reducers.
Also notice that when i ignore the arguments of some functions i have replaced all the unused hyperparameters with `*_` or `**__` to follow standard python coding style. Is this pull request satisfactory to solve #587 and #437 ? What could i add to this to further simplify the files?