### PR TITLE
Add MultipleNegativesRankingLoss

### DIFF
--- a/src/pytorch_metric_learning/losses/__init__.py
+++ b/src/pytorch_metric_learning/losses/__init__.py
@@ -18,6 +18,7 @@ from .margin_loss import MarginLoss
 from .mixins import EmbeddingRegularizerMixin, WeightRegularizerMixin
 from .multi_similarity_loss import MultiSimilarityLoss
 from .multiple_losses import MultipleLosses
+from .multiple_negatives_ranking_loss import MultipleNegativesRankingLoss
 from .n_pairs_loss import NPairsLoss
 from .nca_loss import NCALoss
 from .normalized_softmax_loss import NormalizedSoftmaxLoss

--- a/src/pytorch_metric_learning/losses/multiple_negatives_ranking_loss.py
+++ b/src/pytorch_metric_learning/losses/multiple_negatives_ranking_loss.py
@@ -105,7 +105,7 @@ class MultipleNegativesRankingLoss(BaseMetricLossFunction):
 
     def get_positive_pairwise_sims(self, anchor_embedding, ref_embedding):
         const = 1.0 if self.distance.is_inverted else -1.0
-        return self.distance(anchor_embedding, ref_embedding) * const
+        return self.distance(anchor_embedding, ref_embedding) * const * self.scale
 
     def get_default_distance(self):
         return CosineSimilarity()

--- a/src/pytorch_metric_learning/losses/multiple_negatives_ranking_loss.py
+++ b/src/pytorch_metric_learning/losses/multiple_negatives_ranking_loss.py
@@ -48,7 +48,7 @@ class MultipleNegativesRankingLoss(BaseMetricLossFunction):
                 self.calculate_anchor_positive_loss(embeddings, anc, pos_idx, neg_idx)
             )
 
-        loss = [torch.stack(v).mean() for v in anchor_losses.values()]
+        loss = torch.stack([(torch.stack(v).mean()) for v in anchor_losses.values()])
         return {
             "loss": {
                 "losses": loss,

--- a/src/pytorch_metric_learning/losses/multiple_negatives_ranking_loss.py
+++ b/src/pytorch_metric_learning/losses/multiple_negatives_ranking_loss.py
@@ -1,0 +1,111 @@
+from collections import defaultdict
+
+import torch
+from torch import nn
+
+from ..distances import CosineSimilarity
+from ..utils import common_functions as c_f
+from ..utils import loss_and_miner_utils as lmu
+from .base_metric_loss_function import BaseMetricLossFunction
+
+
+class MultipleNegativesRankingLoss(BaseMetricLossFunction):
+    """
+    Args:
+        scale: The scale factor for the loss
+        positives_per_anchor: The number of positives per element to sample within a
+            batch. Can be an integer or the string "all".
+
+    Reference:
+        `Henderson et al. 2017 <https://arxiv.org/pdf/1705.00652.pdf>`
+    """
+
+    def __init__(self, scale: float = 20.0, **kwargs):
+        super().__init__(**kwargs)
+        self.scale = scale
+        self.cross_entropy_loss = nn.CrossEntropyLoss()
+
+    def compute_loss(
+        self,
+        embeddings,
+        labels,
+        indices_tuple,
+        ref_emb,
+        ref_labels,
+    ):
+        c_f.labels_or_indices_tuple_required(labels, indices_tuple)
+
+        if indices_tuple is None:
+            a, pos, a_neg_idx, neg = lmu.get_all_pairs_indices(labels, labels)
+        else:
+            a, pos, a_neg_idx, neg = lmu.convert_to_pairs(indices_tuple, labels, labels)
+
+        anchor_losses = defaultdict(list)
+        for idx, anc in enumerate(a):
+            pos_idx = pos[idx]
+            neg_idx = neg[a_neg_idx == anc]
+            anchor_losses[anc.item()].append(
+                self.calculate_anchor_positive_loss(embeddings, anc, pos_idx, neg_idx)
+            )
+
+        loss = [torch.stack(v).mean() for v in anchor_losses.values()]
+        return {
+            "loss": {
+                "losses": loss,
+                "indices": c_f.torch_arange_from_size(embeddings),
+                "reduction_type": "element",
+            }
+        }
+
+    def calculate_anchor_positive_loss(
+        self, embeddings, anchor_idx, positive_idx, negative_idx
+    ):
+        """
+        Calculates the loss for a given anchor-positive pair and negative samples.
+
+        Args:
+            embeddings: tensor of shape (batch_size, embedding_size)
+            anchor_idx: index of the anchor embedding in the embeddings tensor
+            positive_idx: index of the positive embedding in the embeddings tensor
+            negative_idx: index of the negative embeddings in the embeddings tensor
+
+        Returns:
+            loss: tensor representing the calculated loss for the given anchor-positive pair and negative samples
+        """
+        logits = self.get_logits(embeddings, anchor_idx, positive_idx, negative_idx)
+        target = torch.zeros(len(logits)).to(embeddings.device)
+        target[0] = 1
+        return self.cross_entropy_loss(logits, target)
+
+    def get_logits(self, embeddings, anchor_idx, positive_idx, negative_idx):
+        """
+        Calculates the pairwise similarities between embeddings using the specified
+        distance function. Those similarities will be treated as logits in the cross
+        entropy loss that this class uses.
+
+        Args:
+            embeddings: tensor of shape (batch_size, embedding_size)
+
+        Returns:
+            pairwise_sims: tensor of shape (batch_size, batch_size) containing the
+                pairwise similarities between embeddings
+        """
+        anchor_embedding = embeddings[anchor_idx].reshape(1, -1)
+        positive_embedding = embeddings[positive_idx].reshape(1, -1)
+        negative_embeddings = embeddings[negative_idx]
+        positive_pairwise_sims = self.get_positive_pairwise_sims(
+            anchor_embedding, positive_embedding
+        )
+        negative_pairwise_sims = self.get_positive_pairwise_sims(
+            anchor_embedding, negative_embeddings
+        )
+        return torch.cat(
+            [positive_pairwise_sims.flatten(), negative_pairwise_sims.flatten()]
+        )
+
+    def get_positive_pairwise_sims(self, anchor_embedding, ref_embedding):
+        const = 1.0 if self.distance.is_inverted else -1.0
+        return self.distance(anchor_embedding, ref_embedding) * const
+
+    def get_default_distance(self):
+        return CosineSimilarity()

--- a/tests/losses/test_multiple_negatives_ranking_loss.py
+++ b/tests/losses/test_multiple_negatives_ranking_loss.py
@@ -1,0 +1,93 @@
+import unittest
+
+import torch
+
+from pytorch_metric_learning.distances import DotProductSimilarity
+from pytorch_metric_learning.losses import MultipleNegativesRankingLoss
+from pytorch_metric_learning.miners import BatchEasyHardMiner
+
+from .. import TEST_DEVICE, TEST_DTYPES
+
+
+class TestTripletMarginLoss(unittest.TestCase):
+    def test_multiple_negatives_ranking_loss(self):
+        for dtype in TEST_DTYPES:
+            embeddings = torch.randn(
+                5,
+                32,
+                requires_grad=True,
+                dtype=dtype,
+            ).to(TEST_DEVICE)
+            labels = torch.LongTensor([0, 0, 1, 1, 1])
+            self.helper(embeddings, labels, None, dtype)
+
+    def test_multiple_negatives_ranking_loss_with_miner(self):
+        miner = BatchEasyHardMiner(pos_strategy="hard", neg_strategy="all")
+        for dtype in TEST_DTYPES:
+            embeddings = torch.randn(
+                5,
+                32,
+                requires_grad=True,
+                dtype=dtype,
+            ).to(TEST_DEVICE)
+            labels = torch.LongTensor([0, 0, 1, 1, 1])
+            triplets = miner(embeddings, labels)
+            self.helper(embeddings, labels, triplets, dtype)
+
+    def helper(
+        self, embeddings, labels, triplets, dtype, ref_emb=None, ref_labels=None
+    ):
+        loss_funcA = MultipleNegativesRankingLoss()
+        loss_funcB = MultipleNegativesRankingLoss(scale=0.5)
+        loss_funcC = MultipleNegativesRankingLoss(
+            distance=DotProductSimilarity(normalize_embeddings=False)
+        )
+        [lossA, lossB, lossC] = [
+            x(
+                embeddings,
+                labels,
+                ref_emb=ref_emb,
+                ref_labels=ref_labels,
+                indices_tuple=triplets,
+            )
+            for x in [loss_funcA, loss_funcB, loss_funcC]
+        ]
+        self.assertTrue(lossC > lossA > lossB)
+
+    def test_calculate_anchor_positive_loss(self):
+        mnrl = MultipleNegativesRankingLoss()
+        for dtype in TEST_DTYPES:
+            embeddings = torch.randn(
+                5,
+                32,
+                requires_grad=True,
+                dtype=dtype,
+            ).to(TEST_DEVICE)
+            anchor_idx = torch.arange(5, dtype=torch.long)
+            positive_idx = [1, 0, 3, 2, 4]
+            negative_idx = [[2, 3, 4], [2, 3, 4], [0, 1], [0, 1], [0, 1]]
+            for idx in range(5):
+                loss = mnrl.calculate_anchor_positive_loss(
+                    embeddings, anchor_idx[idx], positive_idx[idx], negative_idx[idx]
+                )
+                self.assertTrue(loss.item() >= 0)
+                self.assertTrue(loss.requires_grad)
+
+    def test_get_logits(self):
+        mnrl = MultipleNegativesRankingLoss()
+        for dtype in TEST_DTYPES:
+            embeddings = torch.randn(
+                5,
+                32,
+                requires_grad=True,
+                dtype=dtype,
+            ).to(TEST_DEVICE)
+            anchor_idx = torch.arange(5, dtype=torch.long)
+            positive_idx = [1, 0, 3, 2, 4]
+            negative_idx = [[2, 3, 4], [2, 3, 4], [0, 1], [0, 1], [0, 1]]
+            for idx in range(5):
+                logits = mnrl.get_logits(
+                    embeddings, anchor_idx[idx], positive_idx[idx], negative_idx[idx]
+                )
+                self.assertEqual(logits.shape, (len(negative_idx[idx]) + 1,))
+                self.assertTrue(logits.requires_grad)


### PR DESCRIPTION
Adds the `MultipleNegativesRankingLoss` as in #664 

The [reference paper](https://arxiv.org/pdf/1705.00652.pdf) assumes one single positive per anchor. However, if there are multiple positive samples for an anchor, this implementation calculates the loss for all combinations of anchors and positives and takes the average by anchor.
This could theoretically be bypassed by using a miner, that only returns the hardest positive.