### PR TITLE
indices_tuple: Add assertion that each pair should be either positive or negative

### DIFF
--- a/src/pytorch_metric_learning/losses/generic_pair_loss.py
+++ b/src/pytorch_metric_learning/losses/generic_pair_loss.py
@@ -28,6 +28,7 @@ class GenericPairLoss(BaseMetricLossFunction):
         pos_mask, neg_mask = torch.zeros_like(mat), torch.zeros_like(mat)
         pos_mask[a1, p] = 1
         neg_mask[a2, n] = 1
+        self._assert_either_pos_or_neg(pos_mask, neg_mask)
         return self._compute_loss(mat, pos_mask, neg_mask)
 
     def pair_based_loss(self, mat, indices_tuple):
@@ -38,3 +39,11 @@ class GenericPairLoss(BaseMetricLossFunction):
         if len(a2) > 0:
             neg_pair = mat[a2, n]
         return self._compute_loss(pos_pair, neg_pair, indices_tuple)
+    
+    @staticmethod
+    def _assert_either_pos_or_neg(pos_mask, neg_mask):
+        pos_indices = set(pos_mask.flatten().nonzero().flatten().tolist())
+        neg_indices = set(neg_mask.flatten().nonzero().flatten().tolist())
+        assert (
+            pos_indices.isdisjoint(neg_indices)
+        ), "Each pair should be either be positive or negative"

--- a/src/pytorch_metric_learning/losses/generic_pair_loss.py
+++ b/src/pytorch_metric_learning/losses/generic_pair_loss.py
@@ -42,8 +42,4 @@ class GenericPairLoss(BaseMetricLossFunction):
     
     @staticmethod
     def _assert_either_pos_or_neg(pos_mask, neg_mask):
-        pos_indices = set(pos_mask.flatten().nonzero().flatten().tolist())
-        neg_indices = set(neg_mask.flatten().nonzero().flatten().tolist())
-        assert (
-            pos_indices.isdisjoint(neg_indices)
-        ), "Each pair should be either be positive or negative"
+        assert not torch.any((pos_mask != 0) & (neg_mask != 0)), "Each pair should be either be positive or negative"


### PR DESCRIPTION
While using `indices_tuples` to compute multi-label similarity, I noticed that two embeddings could be at the same time positive and negative pairs without raising an error. For example:
```
a1 = torch.tensor([0, 0, 1])
p = torch.tensor([2, 3, 4])
a2 = torch.tensor([1, 1, 0])
n = torch.tensor([2, 3, 2])
```
, where the 1st positive pair is (a1[0], p[0]), which is (0, 2), which corresponds with (embeddings[0], embeddings[2]).
And the 3rd negative pair is (a2[2], n[2]), which also is (0, 2), which also corresponds with (embeddings[0], embeddings[2]).

Therefore, I added an assertion to make sure that each pair is either positive or negative when using `indices_tuple`.