### PR TITLE
Fix kwargs not passed to SubCenterArcFaceLoss

### DIFF
--- a/src/pytorch_metric_learning/losses/subcenter_arcface_loss.py
+++ b/src/pytorch_metric_learning/losses/subcenter_arcface_loss.py
@@ -1,4 +1,5 @@
 import math
+from copy import deepcopy
 
 import numpy as np
 import torch
@@ -13,9 +14,12 @@ class SubCenterArcFaceLoss(ArcFaceLoss):
     """
 
     def __init__(self, *args, margin=28.6, scale=64, sub_centers=3, **kwargs):
-        num_classes, embedding_size = kwargs["num_classes"], kwargs["embedding_size"]
+        num_classes = deepcopy(kwargs["num_classes"])
+        embedding_size = deepcopy(kwargs["embedding_size"])
+        del kwargs["num_classes"]
+        del kwargs["embedding_size"]
         super().__init__(
-            num_classes * sub_centers, embedding_size, margin=margin, scale=scale
+            num_classes=num_classes * sub_centers, embedding_size=embedding_size, margin=margin, scale=scale, **kwargs
         )
         self.sub_centers = sub_centers
         self.num_classes = num_classes

--- a/tests/losses/test_subcenter_arcface_loss.py
+++ b/tests/losses/test_subcenter_arcface_loss.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn.functional as F
 
 from pytorch_metric_learning.losses import ArcFaceLoss, SubCenterArcFaceLoss
+from pytorch_metric_learning.reducers import DoNothingReducer
 
 from .. import TEST_DEVICE, TEST_DTYPES
 
@@ -142,3 +143,19 @@ class TestSubCenterArcFaceLoss(unittest.TestCase):
                     )
                     == 0
                 )
+
+    def test_reducer_subcenter_arcface(self):
+
+        arcfaceloss = SubCenterArcFaceLoss(
+            num_classes=10,
+            sub_centers=3,
+            embedding_size=64,
+            reducer=DoNothingReducer(),
+        )
+        
+        emb = torch.randn(4, 64)
+        result = arcfaceloss(emb, torch.arange(4))
+
+        self.assertTrue(isinstance(result, dict))
+        self.assertTrue(result['loss']['losses'].shape[0] == 4)
+        


### PR DESCRIPTION
`**kwargs` are not passed into `__init__` of `SubCenterArcFaceLoss`.

This leads to problems, for example with `reducers`, which have no effect when passed.

Example bug:
```
arcfaceloss = SubCenterArcFaceLoss(
    num_classes=10,
    sub_centers=3,
    embedding_size=64,
    reducer=DoNothingReducer(),
)

emb = torch.randn(4, 64)
print(arcfaceloss(emb, torch.arange(4)))

# without fix, we get the mean of the losses, which is the default reducer, despite passing `DoNothingReducer` to the `init`.
> tensor(39.9293, grad_fn=<MeanBackward0>)

# with fix, the reducer is properly passed and is properly applied.
> {'loss': {'losses': tensor([53.9860, 42.8221, 38.8233, 62.1092], grad_fn=<MulBackward0>), 'indices': tensor([0, 1, 2, 3]), 'reduction_type': 'element'}}
```

The fix includes the use of `deepcopy` to ensure no reference problems occur when deleting the keys form `**kwargs`, which is necessary otherwise duplicate keys are passed into `__init__`. But perhaps it can be done more elegantly.